### PR TITLE
Fixes for `no-std` build

### DIFF
--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -15,11 +15,6 @@ version = "1"
 features = [ "derive" ]
 default-features = false
 
-[dependencies.heapless]
-version = "0.7"
-features = [ "serde" ]
-optional = true
-
 [features]
 std = []
 default = [ "std" ]

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -13,6 +13,7 @@ rev = "d98084b85cc45fe589a49dd95403d7b41533375c"
 [dependencies.serde]
 version = "1"
 features = [ "derive" ]
+default-features = false
 
 [dependencies.heapless]
 version = "0.7"

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -193,7 +193,7 @@ fn port_to_ids(port: u8) -> Result<(Fpga, u8), Error> {
     Fpga::try_from(fpga_id).map(|fpga| (fpga, port_index))
 }
 
-pub fn ids_from_logical_ports(ports: &[u8]) -> Result<Vec<ModuleId>, Error> {
+pub fn ids_from_logical_ports(ports: &[u8]) -> Result<[ModuleId; 2], Error> {
     let mut port_indices: Vec<(Fpga, Vec<u8>)> = Vec::with_capacity(2);
     for port in ports {
         let (this_fpga, index) = port_to_ids(*port)?;
@@ -219,10 +219,10 @@ mod tests {
 
     #[test]
     fn test_port_mask_from_indices() {
-        let ix = &[0, 1, 2];
-        let mask = PortMask::from_indices(ix).unwrap();
+        let ix = vec![0, 1, 2];
+        let mask = PortMask::from_indices(&ix).unwrap();
         assert_eq!(u32::from(mask), 0b111);
-        assert_eq!(mask.to_indices().as_slice(), ix);
+        assert_eq!(mask.to_indices().collect::<Vec<_>>(), ix);
     }
 
     #[test]

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -109,15 +109,8 @@ impl PortMask {
     }
 
     /// Return the indices of the ports identified by the bitmask.
-    pub fn to_indices(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(usize::from(Self::NUM_PORTS));
-        for i in 0..Self::NUM_PORTS {
-            let i = i as u8;
-            if self.is_set(i).unwrap() {
-                out.push(i);
-            }
-        }
-        out
+    pub fn to_indices(&self) -> impl Iterator<Item = u8> + '_ {
+        (0..Self::NUM_PORTS).filter(|i| self.is_set(*i).unwrap())
     }
 
     /// A convenience function to return a port bitmask identifying a single

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -8,12 +8,6 @@
 
 pub mod message;
 
-#[cfg(all(not(test), not(feature = "std")))]
-use heapless::Vec;
-
-#[cfg(any(test, feature = "std"))]
-use std::vec::Vec;
-
 use hubpack::SerializedSize;
 use serde::Deserialize;
 use serde::Serialize;
@@ -173,7 +167,7 @@ impl core::fmt::UpperHex for ModuleId {
 }
 
 // Map a logical port to the FPGA and per-FPGA port index.
-fn port_to_ids(port: u8) -> Result<(Fpga, u8), Error> {
+pub fn port_to_ids(port: u8) -> Result<(Fpga, u8), Error> {
     // There are 16 ports per FPGA, with a stride of 8. That is:
     //
     // Logical port     FPGA    On-FPGA port
@@ -193,26 +187,8 @@ fn port_to_ids(port: u8) -> Result<(Fpga, u8), Error> {
     Fpga::try_from(fpga_id).map(|fpga| (fpga, port_index))
 }
 
-pub fn ids_from_logical_ports(ports: &[u8]) -> Result<[ModuleId; 2], Error> {
-    let mut port_indices: Vec<(Fpga, Vec<u8>)> = Vec::with_capacity(2);
-    for port in ports {
-        let (this_fpga, index) = port_to_ids(*port)?;
-        match port_indices.iter_mut().find(|(fpga, _)| fpga == &this_fpga) {
-            Some((_, ref mut indices)) => indices.push(index),
-            None => port_indices.push((this_fpga, vec![index])),
-        }
-    }
-    port_indices
-        .into_iter()
-        .map(|(fpga, indices)| {
-            PortMask::from_indices(&indices).map(|ports| ModuleId { fpga, ports })
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
-    use super::ids_from_logical_ports;
     use super::Error;
     use super::Fpga;
     use super::PortMask;
@@ -260,24 +236,5 @@ mod tests {
         assert_eq!(Fpga::try_from(0u8).unwrap(), Fpga::LEFT);
         assert_eq!(Fpga::try_from(1u8).unwrap(), Fpga::RIGHT);
         assert_eq!(Fpga::try_from(10u8), Err(Error::InvalidFpga(10)));
-    }
-
-    #[test]
-    fn test_ids_from_logical_ports() {
-        let logical = (0..PortMask::NUM_PORTS).collect::<Vec<_>>();
-        let ids = ids_from_logical_ports(&logical).unwrap();
-        assert_eq!(ids.len(), 2);
-
-        let id = &ids[0];
-        assert_eq!(id.fpga, Fpga::LEFT);
-        for i in 0..16 {
-            assert!(id.ports.is_set(i).unwrap());
-        }
-
-        let id = &ids[1];
-        assert_eq!(id.fpga, Fpga::RIGHT);
-        for i in 0..16 {
-            assert!(id.ports.is_set(i).unwrap());
-        }
     }
 }


### PR DESCRIPTION
- Fix Serde dependency to build with `no_std`
- Remove `ids_from_logical_ports`, since Ben was already planning to delete it
- Change the one remaining function that returned a `Vec` -> returning an iterator instead
- Drop `heapless` dependency, since we don't need it anymore
- Update tests
- Make `port_to_ids` public, since otherwise no one is using it (?)