### PR TITLE
Adds mechanisms to specify which management interface a transceiver uses

### DIFF
--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -59,9 +59,11 @@ pub enum Error {
     /// A request would result in a response that is too large to fit in a
     /// single UDP message.
     RequestTooLarge,
-    /// Someone sent an unexpected message (e.g. the host sending an SpRequest)
+
+    /// Someone sent an unexpected message (e.g. the host sending an SpRequest).
     ProtocolError,
-    /// The version in the header is unexpected
+
+    /// The version in the header is unexpected.
     VersionMismatch,
 }
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -65,8 +65,16 @@ pub enum Error {
     VersionMismatch,
 }
 
-type MaskType = u32;
+// We're currently only expecting to be able to address up to 16 transceivers
+// per Sidecar FPGA. The `PortMask` below exposes this publicly, so we may wish
+// to hide it if / when we want to support other front I/O board designs with
+// different arrangements of FPGAs and / or transceivers.
+type MaskType = u16;
 
+/// A bitmask used to identify the set of transceiver ports to which a message
+/// applies.
+///
+/// Note that this bitmask is always per-FPGA.
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize, SerializedSize)]
 pub struct PortMask(pub MaskType);
 
@@ -184,7 +192,7 @@ mod tests {
 
     #[test]
     fn test_port_mask_test_set_clear() {
-        let mut mask = PortMask(0b101u32);
+        let mut mask = PortMask(0b101);
         assert!(mask.is_set(0).unwrap());
         assert!(!mask.is_set(1).unwrap());
         assert!(mask.is_set(2).unwrap());

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -150,24 +150,6 @@ pub struct ModuleId {
     pub ports: PortMask,
 }
 
-// Notes:
-//
-// Address 1 FPGA at a time in each message, a const-sized bitmask (u32? u64?)
-// for the ports on it.
-//
-// Dendrite knows how to go from logical port to (fpga_id, bit), based on the
-// front IO board identity.
-//
-// Need message to tell SP the kind of device in any given port. Really it's
-// which spec it conforms to, so that it can go read the temperature correctly
-// from the memory map and plug that into its thermal loop.
-//
-// Be aware that a read for more than one device returns a uint8_t ** -- I.e.,
-// we get an array of buffers, one for the data read in for each device.
-//
-// Same thing for a write, unless we want to only support writing the same data
-// to every port.
-
 #[cfg(test)]
 mod tests {
     use super::Error;

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -75,6 +75,11 @@ pub enum HostRequest {
     /// allows us to explicitly power down a transceiver. That is useful for
     /// ensuring that there's no wasted power, for example, when a customer
     /// purposefully disables a transceiver via the control plane.
+    ///
+    /// Note that the _host side_ is responsible for ensuring that a transition
+    /// to high-power mode is valid. The host guarantees that it has applied
+    /// the configuration required by the module, prior to requesting such a
+    /// transition.
     SetPowerMode(PowerMode),
 
     /// Assert type of management interface that a set of modules uses.
@@ -186,6 +191,7 @@ pub enum PowerMode {
     ///
     /// Note that additional configuration may be required to correctly
     /// configure the module, such as described in SFF-8636 rev 2.10a table
-    /// 6-10.
+    /// 6-10, and that the _host side_ is responsible for ensuring that the
+    /// relevant configuration is applied.
     High,
 }

--- a/messages/src/mgmt/cmis.rs
+++ b/messages/src/mgmt/cmis.rs
@@ -1,0 +1,105 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Types for working with transceivers conforming to the Common Management
+//! Interface Specification (CMIS) version 5.0.
+
+use crate::Error;
+use hubpack::SerializedSize;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize, SerializedSize)]
+pub struct Page {
+    bank: Option<u8>,
+    page: u8,
+}
+
+impl Page {
+    /// Create a new page that does not accept a bank number.
+    ///
+    /// If the requested page number is invalid, an error is returned. If the
+    /// requested page number _does_ accept a bank, an error is returned.
+    pub fn new_unbanked(page: u8) -> Result<Self, Error> {
+        if page_accepts_bank_number(page) {
+            return Err(Error::PageIsBanked(page));
+        }
+        Ok(Self { bank: None, page })
+    }
+
+    /// Create a new page that _does_ require a bank number.
+    ///
+    /// An error is returned if:
+    ///
+    /// - The requested page number is invalid.
+    /// - The requested page number does _not_ accept a bank.
+    /// - The requested bank number is invalid.
+    pub fn new_banked(page: u8, bank: u8) -> Result<Self, Error> {
+        if !is_valid_page(page) {
+            return Err(Error::InvalidPage(page));
+        }
+        if bank > MAX_BANK {
+            return Err(Error::InvalidBank(bank));
+        }
+        if !page_accepts_bank_number(page) {
+            return Err(Error::PageIsUnbanked(page));
+        }
+        Ok(Self {
+            bank: Some(bank),
+            page,
+        })
+    }
+
+    pub fn page(&self) -> u8 {
+        self.page
+    }
+
+    pub fn bank(&self) -> Option<u8> {
+        self.bank
+    }
+}
+
+// See CMIS 5.0 rev 4.0 Figure 8-1 for details.
+fn is_valid_page(page: u8) -> bool {
+    matches!(
+        page,
+        // Identity, advertising, thresholds, laser control.
+        0x00..=0x04 |
+        // Banked pages.
+        0x10..=0x3F | 0x9F | 0xA0..=0xAF |
+        // Custom pages.
+        0xB0..=0xFF
+    )
+}
+
+// See CMIS 5.0 rev 4.0 Figure 8-1 for details.
+fn page_accepts_bank_number(page: u8) -> bool {
+    matches!(page, 0x10..=0x3F | 0x9F | 0xA0..=0xAF)
+}
+
+/// The maximum valid bank number supported by CMIS.
+pub const MAX_BANK: u8 = 0x03;
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+    use super::Page;
+
+    #[test]
+    fn test_page() {
+        assert!(Page::new_unbanked(0x00).is_ok());
+        assert!(Page::new_unbanked(0xFF).is_ok());
+        assert!(matches!(
+            Page::new_banked(0x00, 0x01),
+            Err(Error::PageIsUnbanked(_))
+        ));
+        assert!(matches!(
+            Page::new_banked(0x10, 0x10),
+            Err(Error::InvalidBank(_))
+        ));
+        assert!(Page::new_banked(0x10, 0x01).is_ok());
+    }
+}

--- a/messages/src/mgmt/mod.rs
+++ b/messages/src/mgmt/mod.rs
@@ -1,0 +1,222 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Specifications for transceiver management interfaces.
+
+pub mod cmis;
+pub mod sff8636;
+
+use crate::Error;
+use hubpack::SerializedSize;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// The specification to which a transciever's management interface conforms.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, SerializedSize)]
+pub enum ManagementInterface {
+    /// SFF-8636, which covers QSFP+ and QSFP28.
+    Sff8636,
+    /// Common Management Interface Specification version 5, which covers QSFPDD
+    /// and OSFP.
+    Cmis,
+    /// Any other interface specification, unsupported at this time.
+    Unknown(u8),
+}
+
+/// A description of how to page in the upper 128-bytes of a transceiver's
+/// memory map.
+///
+/// There are several specifications that define the memory map for a free-side
+/// transceiver monitor. (See [`ManagementInterface`] for details.) Though there
+/// are lots of variations, all supported specifications split this space into
+/// two 128-byte pages: a fixed lower page and one or more upper pages.
+///
+/// Paging versus flat
+/// ------------------
+///
+/// No matter the spec, a module's lower page is fixed and always available.
+/// This supports data shared across all kinds of devices, and data where access
+/// time is important, such as for control. Some simple devices contain a single
+/// fixed upper page, in which case the module is considered to have "flat
+/// memory".
+///
+/// For more complex devices, many upper pages are supported, and the map is
+/// referred to in the specs as "paged memory". These can be swapped out on
+/// demand, by writing to a specific page-select byte, `0x7F` to choose which
+/// upper page is accessed. These pages have a set of allow page numbers to
+/// identify them, which vary depending on the spec. Also note that not all
+/// modules support all allowed pages, instead advertising what is supported in
+/// the lower memory page.
+///
+/// Pages and banks
+/// ---------------
+///
+/// In CMIS 5.0, the concept of page _banks_ was introduced, to allow an
+/// additional level of paging. A bank of pages is several "copies" of the same
+/// page number. The rationale for another level of nesting is to support
+/// information on a per-lane basis, such as independent power measurements or
+/// alerts.
+///
+/// This is only valid for modules conforming to CMIS 5.0. The bank-select by is
+/// immediately before the page-select byte, at `0x7E`. As with pages, note that
+/// not all banks are supported by all modules.
+///
+/// Accessing specific pages
+/// ------------------------
+///
+/// This network protocol requires that all memory accesses specify which page
+/// they would like to address. This is required so that the SP can correctly
+/// ask the actual free-side module to swap in the right page, and then read or
+/// write it as the host requested, all atomically from the point of view of the
+/// client(s).
+///
+/// > Important! It's the responsibility of the _host_ to determine if a given
+/// page or bank is supported by any particular module. We'd like to keep as
+/// much intelligence about parsing the memory maps in the host as possible,
+/// including identifying the management specification, and which pages if any
+/// are supported for a module. The intention is for the SP to only interpret
+/// sections of the map insofar as required for temperature and power
+/// monitoring.
+///
+/// Note that modules generally don't _fail_ a memory access to an unsupported
+/// page. Instead, modules generally just revert the page- or bank-select bytes
+/// to those known to be valid, usually zero. That means the client _must_ keep
+/// track of which bank and/or page is being accessed, and validate that those
+/// are actually supported by the module prior to operating on them.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, SerializedSize)]
+pub enum UpperPage {
+    Sff8636(sff8636::Page),
+    Cmis(cmis::Page),
+}
+
+impl UpperPage {
+    /// Return the actual page number of the upper page being mapped in.
+    pub fn page(&self) -> u8 {
+        match self {
+            UpperPage::Sff8636(inner) => inner.page(),
+            UpperPage::Cmis(inner) => inner.page(),
+        }
+    }
+
+    /// Return the bank of the upper page being accessed.
+    ///
+    /// Note that this returns `None` for pages that don't have a bank, e.g.,
+    /// those for modules conforming to SFF-8636.
+    ///
+    /// For those which _may_ have a bank, this _may_ return `Some(_)`. Note
+    /// that not all CMIS-defined pages allow a bank, so it may still return
+    /// `None` in that case.
+    pub fn bank(&self) -> Option<u8> {
+        match self {
+            UpperPage::Sff8636(_) => None,
+            UpperPage::Cmis(inner) => inner.bank(),
+        }
+    }
+}
+
+impl From<sff8636::Page> for UpperPage {
+    fn from(p: sff8636::Page) -> Self {
+        Self::Sff8636(p)
+    }
+}
+
+impl From<cmis::Page> for UpperPage {
+    fn from(p: cmis::Page) -> Self {
+        Self::Cmis(p)
+    }
+}
+
+/// A description of a region of a transceiver's memory map.
+///
+/// See [`UpperPage`] for a detailed description of how a module's upper page is
+/// mapped in for an operation. This type also performs validation against the
+/// offset / length, to ensure they're a valid access for the 256-byte memory
+/// map of all transceiver modules we support.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, SerializedSize)]
+pub struct MemoryRegion {
+    upper_page: UpperPage,
+    offset: u8,
+    len: u8,
+}
+
+impl MemoryRegion {
+    /// Construct a new memory region.
+    ///
+    /// Note that you must specify an `upper_page`, even if you are only
+    /// accessing the fixed, lower page of memory. In that case, you can use
+    /// the default for the specification of the accessed module, which uses
+    /// page and / or bank zero.
+    pub fn new(upper_page: UpperPage, offset: u8, len: u8) -> Result<Self, Error> {
+        // The last accessed byte must be within the 256-byte memory map.
+        if offset.checked_add(len).is_none() {
+            return Err(Error::InvalidMemoryAccess { offset, len });
+        }
+
+        // TODO-correctness: Whether / how to handle zero-byte accesses?
+        Ok(Self {
+            upper_page,
+            offset,
+            len,
+        })
+    }
+
+    /// Return the information about the mapped upper page of this memory
+    /// region.
+    pub fn upper_page(&self) -> &UpperPage {
+        &self.upper_page
+    }
+
+    /// Return the actual page number of the upper page being mapped in.
+    ///
+    /// See [`UpperPage::page`] for details.
+    pub fn page(&self) -> u8 {
+        self.upper_page.page()
+    }
+
+    /// Return the bank of the upper page being accessed.
+    ///
+    /// See [`UpperPage::bank`] for details.
+    pub fn bank(&self) -> Option<u8> {
+        self.upper_page.bank()
+    }
+
+    /// Return the offset into the transceiver memory map for the operation.
+    pub fn offset(&self) -> u8 {
+        self.offset
+    }
+
+    /// Return the length of transceiver memory for the operation.
+    pub fn len(&self) -> u8 {
+        self.len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::mgmt::sff8636;
+    use crate::mgmt::MemoryRegion;
+    use crate::mgmt::UpperPage;
+    use crate::Error;
+
+    #[test]
+    fn test_memory_region() {
+        let page = UpperPage::Sff8636(sff8636::Page::default());
+        let region = MemoryRegion::new(page, 0, 10).unwrap();
+        assert_eq!(region.upper_page(), &page);
+        assert_eq!(region.page(), page.page());
+        assert!(region.bank().is_none());
+
+        // Would read past map end.
+        assert!(matches!(
+            MemoryRegion::new(page, 1, 255).unwrap_err(),
+            Error::InvalidMemoryAccess { .. }
+        ));
+        assert!(matches!(
+            MemoryRegion::new(page, 255, 1).unwrap_err(),
+            Error::InvalidMemoryAccess { .. }
+        ));
+    }
+}

--- a/messages/src/mgmt/sff8636.rs
+++ b/messages/src/mgmt/sff8636.rs
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Types for working with transceivers conforming to the SFF-8636 management
+//! interface specification.
+
+use crate::Error;
+use hubpack::SerializedSize;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize, SerializedSize)]
+pub struct Page(u8);
+
+impl Page {
+    pub fn new(page_number: u8) -> Result<Self, Error> {
+        if matches!(
+        page_number,
+        // Static module identity and capabilities.
+        0x00 |
+        // User read/write space.
+        0x02 |
+        // Static monitor thresholds, advertising and channel controls.
+        0x03 |
+        // Additional monitored parameters for PAM4 / DWDM modules.
+        0x20..=0x21 |
+        // Vendor-specific functions.
+        0x04..=0x1F |
+        // Vendor-specific functions.
+        0x80..=0xFF
+        ) {
+            Ok(Self(page_number))
+        } else {
+            Err(Error::InvalidPage(page_number))
+        }
+    }
+
+    pub fn page(&self) -> u8 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+    use super::Page;
+
+    #[test]
+    fn test_page() {
+        assert!(Page::new(0x00).is_ok());
+        assert!(Page::new(0xFF).is_ok());
+        assert!(matches!(Page::new(0x22), Err(Error::InvalidPage(_))));
+    }
+}


### PR DESCRIPTION
- Adds support for declaring the management interface specification a transceiver conforms to. Currently supports SFF-8636 and CMIS, all others are unknown and unsupported.
- Adds better mechanisms for addressing the upper page of a transceiver memory map. It now supports an addressing scheme per-specification, which allows the older single-level paged memory of SFF-8636, and the newer page-and-bank-select mechanisms in CMIS. All values are checked against the spec, for both pages and banks, though that doesn't validate against the pages supported by the modules themselves.
- More tests for above.