### PR TITLE
Adds basic host-side controller.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -6,10 +6,12 @@ default-run = "xcvradm"
 
 [dependencies]
 hubpack = "0.1.0"
+serde = "1"
 slog-async = "2"
 slog-term = "2"
 thiserror = "1"
 transceiver-messages = { path = "../messages" }
+usdt = "0.3"
 
 [dependencies.slog]
 version = "2"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -2,10 +2,19 @@
 name = "transceiver-controller"
 version = "0.1.0"
 edition = "2021"
+default-run = "xcvradm"
 
 [dependencies]
+hubpack = "0.1.0"
+slog-async = "2"
+slog-term = "2"
+thiserror = "1"
 transceiver-messages = { path = "../messages" }
+
+[dependencies.slog]
+version = "2"
+features = [ "max_level_trace", "release_max_level_trace" ]
 
 [dependencies.tokio]
 version = "1"
-features = [ "full" ]
+features = [ "macros", "net", "rt", "rt-multi-thread", "sync", "time" ]

--- a/controller/src/bin/mock-sp.rs
+++ b/controller/src/bin/mock-sp.rs
@@ -9,15 +9,15 @@ use transceiver_messages::message::MessageBody;
 use transceiver_messages::message::SpResponse;
 use transceiver_messages::MAX_PAYLOAD_SIZE;
 use transceiver_messages::PORT;
-
-const PEER: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0x1de, 2);
+use transceiver_messages::ADDR;
 
 #[tokio::main]
 async fn main() {
+    let peer = Ipv6Addr::from(ADDR);
     let sock = UdpSocket::bind(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, PORT, 0, 0))
         .await
         .unwrap();
-    sock.join_multicast_v6(&PEER, 0).unwrap();
+    sock.join_multicast_v6(&peer, 0).unwrap();
 
     let mut buf = [0; MAX_PAYLOAD_SIZE * 2];
     loop {

--- a/controller/src/bin/mock-sp.rs
+++ b/controller/src/bin/mock-sp.rs
@@ -1,0 +1,55 @@
+//! Mock SP server that dummies up basic QSFP memory map.
+
+use std::net::Ipv6Addr;
+use std::net::SocketAddrV6;
+use tokio::net::UdpSocket;
+use transceiver_messages::message::HostRequest;
+use transceiver_messages::message::Message;
+use transceiver_messages::message::MessageBody;
+use transceiver_messages::message::SpResponse;
+use transceiver_messages::MAX_PAYLOAD_SIZE;
+use transceiver_messages::PORT;
+
+const PEER: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0x1de, 2);
+
+#[tokio::main]
+async fn main() {
+    let sock = UdpSocket::bind(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, PORT, 0, 0))
+        .await
+        .unwrap();
+    sock.join_multicast_v6(&PEER, 0).unwrap();
+
+    let mut buf = [0; MAX_PAYLOAD_SIZE * 2];
+    loop {
+        match sock.recv_from(&mut buf).await {
+            Err(e) => println!("{e:?}"),
+            Ok((n_bytes, peer)) => {
+                let (message, _) = hubpack::deserialize::<Message>(&buf[..n_bytes]).unwrap();
+                println!("=> {message:?}");
+                match message.body {
+                    MessageBody::HostRequest(HostRequest::Read(read)) => {
+                        let response = Message {
+                            header: message.header,
+                            modules: message.modules,
+                            body: MessageBody::SpResponse(SpResponse::Read(read)),
+                        };
+                        // Flat array of data.
+                        let data = vec![
+                            0;
+                            usize::from(read.len())
+                                * message.modules.ports.0.count_ones() as usize
+                        ];
+                        println!("data size: {}", data.len());
+                        println!("<= {response:?}");
+                        let n_bytes = hubpack::serialize(&mut buf, &response).unwrap();
+                        buf[n_bytes..n_bytes + data.len()].copy_from_slice(&data);
+                        sock.send_to(&buf[..n_bytes + data.len()], &peer)
+                            .await
+                            .unwrap();
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}

--- a/controller/src/bin/mock-sp.rs
+++ b/controller/src/bin/mock-sp.rs
@@ -7,9 +7,9 @@ use transceiver_messages::message::HostRequest;
 use transceiver_messages::message::Message;
 use transceiver_messages::message::MessageBody;
 use transceiver_messages::message::SpResponse;
+use transceiver_messages::ADDR;
 use transceiver_messages::MAX_PAYLOAD_SIZE;
 use transceiver_messages::PORT;
-use transceiver_messages::ADDR;
 
 #[tokio::main]
 async fn main() {

--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -1,0 +1,41 @@
+use slog::Drain;
+use transceiver_controller::Controller;
+use transceiver_controller::Error;
+use transceiver_controller::HostRpcResponse;
+use transceiver_controller::SpRpcRequest;
+use transceiver_messages::mgmt::sff8636;
+use transceiver_messages::mgmt::MemoryRead;
+use transceiver_messages::Error as MessageError;
+use transceiver_messages::ModuleId;
+use transceiver_messages::PortMask;
+
+async fn request_handler(_: SpRpcRequest) -> Result<HostRpcResponse, Error> {
+    Err(Error::Protocol(MessageError::ProtocolError))
+}
+
+#[tokio::main]
+async fn main() {
+    let decorator = slog_term::TermDecorator::new().build();
+    let drain = slog_term::FullFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).build().fuse();
+    let log = slog::Logger::root(drain, slog::o!());
+
+    let request_handler_log = log.new(slog::o!("name" => "request_handler"));
+    let handler = move |message| {
+        slog::info!(request_handler_log, "received sp request"; "message" => ?message);
+        async move { request_handler(message).await }
+    };
+    let controller = Controller::new(log.clone(), handler).await.unwrap();
+    let read = MemoryRead::new(sff8636::Page::Lower, 0, 4).unwrap();
+    let data = controller
+        .read(
+            ModuleId {
+                fpga_id: 0,
+                ports: PortMask(0b11),
+            },
+            read,
+        )
+        .await
+        .unwrap();
+    slog::info!(log, "data: {:?}", data);
+}

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -123,7 +123,8 @@ pub struct Controller {
     // The task handling actual network IO with the peer.
     io_task: JoinHandle<()>,
 
-    // The task handling actual network IO with the peer.
+    // The task receiving requests from the peer and calling the user-supplied
+    // request handler.
     request_task: JoinHandle<()>,
 }
 

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -2,10 +2,605 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// Copyright 2022 Oxide Computer Company
+
 //! A host-side control interface to the SP for managing Sidecar transceivers.
 
+use hubpack::SerializedSize;
+use slog::debug;
+use slog::error;
+use slog::info;
+use slog::warn;
+use slog::Logger;
+use std::future::Future;
+use std::net::Ipv6Addr;
+use std::net::SocketAddr;
+use std::net::SocketAddrV6;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio::time::sleep_until;
+use tokio::time::Instant;
+use transceiver_messages::message;
+use transceiver_messages::message::Header;
+use transceiver_messages::message::HostRequest;
+use transceiver_messages::message::HostResponse;
+use transceiver_messages::message::Message;
+use transceiver_messages::message::MessageBody;
+use transceiver_messages::message::Status;
+use transceiver_messages::mgmt::MemoryRead;
+use transceiver_messages::Error as MessageError;
+use transceiver_messages::ModuleId;
+use transceiver_messages::ADDR;
+use transceiver_messages::MAX_PAYLOAD_SIZE;
+use transceiver_messages::PORT;
+
+/// An error related to managing the transceivers.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Error in transceiver control protocol: {0:?}")]
+    Protocol(#[from] transceiver_messages::Error),
+
+    #[error("Network or I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Message type requires data, but none provided")]
+    MessageRequiresData,
+
+    #[error("A serialization error occurred: {0}")]
+    SerDes(hubpack::Error),
+}
+
+// A request sent from host to SP, possibly with trailing data.
+#[derive(Clone, Debug)]
+struct HostRpcRequest {
+    pub message: Message,
+    pub data: Option<Vec<u8>>,
+}
+
+// A response sent from SP to host, possibly with trailing data.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct SpRpcResponse {
+    pub message: Message,
+    pub data: Option<Vec<u8>>,
+}
+
+/// A request sent from SP to host, possibly with trailing data.
+#[derive(Clone, Debug)]
+pub struct SpRpcRequest {
+    pub message: Message,
+    pub data: Option<Vec<u8>>,
+}
+
+/// A response sent from host to SP, possibly with trailing data.
+#[derive(Clone, Debug)]
+pub struct HostRpcResponse {
+    pub message: Message,
+    pub data: Option<Vec<u8>>,
+}
+
+// A request from host to SP that has not yet been completed.
+#[derive(Debug)]
+struct OutstandingHostRequest {
+    // The actual request object we're sending. It's stored so that we can
+    // resend it if needed.
+    request: HostRpcRequest,
+    // The channel on which the eventual reply will be sent.
+    response_tx: oneshot::Sender<Result<SpRpcResponse, Error>>,
+    // The time we last sent the request, used during retries.
+    last_sent: Instant,
+}
+
+// We limit ourselves to a single outstanding request in either direction at
+// this point.
+const NUM_OUTSTANDING_REQUESTS: usize = 1;
 
 /// A type for controlling transceiver modules on a Sidecar.
 #[derive(Debug)]
-pub struct Controller;
+pub struct Controller {
+    _log: Logger,
+    message_id: AtomicU64,
+
+    // Channel onto which requests from the host to SP are sent.
+    //
+    // `io_task` owns the receiving end of this, and actually sends out the
+    // messages to the SP.
+    outgoing_request_tx: mpsc::Sender<OutstandingHostRequest>,
+
+    // The task handling actual network IO with the peer.
+    io_task: JoinHandle<()>,
+
+    // The task handling actual network IO with the peer.
+    request_task: JoinHandle<()>,
+}
+
+impl Drop for Controller {
+    fn drop(&mut self) {
+        self.io_task.abort();
+        self.request_task.abort();
+    }
+}
+
+impl Controller {
+    /// Create a new transceiver controller.
+    ///
+    /// `request_handler` is a function that yields responses to SP requests. As
+    /// requests over the network are received, they'll be passed into the
+    /// handler, and the yielded response forwarded back to the SP.
+    pub async fn new<H, F>(log: Logger, request_handler: H) -> Result<Self, Error>
+    where
+        H: Fn(SpRpcRequest) -> F + Send + Sync + 'static,
+        F: Future<Output = Result<HostRpcResponse, Error>> + Send,
+    {
+        // TODO-correctness We probably want to accept a specific address as
+        // part of the construction of this object.
+        let local_addr = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, PORT, 0, 0);
+        let socket = UdpSocket::bind(local_addr).await?;
+
+        // Make sure we receive addresses sent to the multicast address we use
+        // for the protocol, but not those sent by us.
+        socket.join_multicast_v6(&Ipv6Addr::from(ADDR), 0)?;
+        socket.set_multicast_loop_v6(false)?;
+
+        // Channel for communicating outgoing requests from this object to the
+        // I/O loop. Note that the _responses_ from the I/O loop back to this
+        // object are sent on a oneshot channel, which is itself placed on this
+        // channel when sending the request.
+        let (outgoing_request_tx, outgoing_request_rx) = mpsc::channel(NUM_OUTSTANDING_REQUESTS);
+
+        // Channel for communicating outgoing responses from the request-handler
+        // task to the I/O loop.
+        let (outgoing_response_tx, outgoing_response_rx) = mpsc::channel(NUM_OUTSTANDING_REQUESTS);
+
+        // Channel for communicating incoming requests from the I/O loop to
+        // the request-handler task.
+        let (incoming_request_tx, incoming_request_rx) = mpsc::channel(NUM_OUTSTANDING_REQUESTS);
+
+        // The I/O task handles the actual network I/O, reading and writing UDP
+        // packets in both directions.
+        let io_log = log.new(slog::o!("task" => "io"));
+        let io_task = tokio::spawn(async move {
+            io_loop(
+                io_log,
+                socket,
+                // For receiving requests sent from self.
+                outgoing_request_rx,
+                // For receiving responses sent from request-handler.
+                outgoing_response_rx,
+                // For sending requests from network to self.
+                incoming_request_tx,
+            )
+            .await;
+        });
+
+        // The request task runs the user-supplied request handler, receiving
+        // valid requests from the I/O task and sending valid responses back.
+        let request_log = log.new(slog::o!("task" => "request_handler"));
+        let request_task = tokio::spawn(async move {
+            request_loop(
+                request_log,
+                // For receiving requests sent from I/O loop.
+                incoming_request_rx,
+                // For sending responses to I/O loop.
+                outgoing_response_tx,
+                request_handler,
+            )
+            .await;
+        });
+
+        Ok(Self {
+            _log: log,
+            message_id: AtomicU64::new(0),
+            outgoing_request_tx,
+            io_task,
+            request_task,
+        })
+    }
+
+    // Return a header using the next available message ID.
+    fn next_header(&self) -> Header {
+        Header {
+            version: message::version::V1,
+            message_id: self.message_id.fetch_add(1, Ordering::SeqCst),
+        }
+    }
+
+    /// Report the status of a set of transceiver modules.
+    pub async fn status(&self, modules: ModuleId) -> Result<Vec<Status>, Error> {
+        let message = Message {
+            header: self.next_header(),
+            modules,
+            body: MessageBody::HostRequest(HostRequest::Status),
+        };
+        let request = HostRpcRequest {
+            message,
+            data: None,
+        };
+        let _reply = self.rpc(request).await.unwrap();
+        todo!();
+    }
+
+    /// Read the memory map of a set of transceiver modules.
+    ///
+    /// `read` contains a description of which memory region to read, including
+    /// the page, offset, and length. See [`MemoryRead`] for details.
+    ///
+    /// Note that the _caller_ is responsible for verifying that the details of
+    /// the read are valid, such as that the modules conform to the specified
+    /// management interface, and that the page is supported.
+    pub async fn read(&self, modules: ModuleId, read: MemoryRead) -> Result<Vec<Vec<u8>>, Error> {
+        let message = Message {
+            header: self.next_header(),
+            modules,
+            body: MessageBody::HostRequest(HostRequest::Read(read)),
+        };
+        let request = HostRpcRequest {
+            message,
+            data: None,
+        };
+        let reply = self.rpc(request).await.unwrap();
+        // We expect data to be a flattened vec of vecs, with the data from each
+        // referenced transceiver. Split it into chunks sized by the number of
+        // bytes we expected to read.
+        let data = reply
+            .data
+            .unwrap()
+            .chunks_exact(usize::from(read.len()))
+            .map(Vec::from)
+            .collect::<Vec<_>>();
+        assert_eq!(data.len(), modules.n_transceivers());
+        Ok(data)
+    }
+
+    // Issue one RPC, possibly retrying, and await the response.
+    async fn rpc(&self, request: HostRpcRequest) -> Result<SpRpcResponse, Error> {
+        let (response_tx, response_rx) = oneshot::channel();
+        let outstanding_request = OutstandingHostRequest {
+            request,
+            response_tx,
+            last_sent: Instant::now(),
+        };
+        self.outgoing_request_tx
+            .send(outstanding_request)
+            .await
+            .unwrap();
+        response_rx.await.unwrap()
+    }
+}
+
+const RESEND_INTERVAL: Duration = Duration::from_secs(1);
+
+// Main IO loop for communicating with the SP.
+//
+// This task is responsible for accepting messages from the host for delivery to
+// the SP (outgoing) and those from the SP to the host (incoming). The outgoing
+// messages are accepted from two channels:
+//
+// - `outgoing_request_rx` receives messages from the `Controller` object
+// itself, as part of the implementation of its public API.
+// - `outgoing_response_rx` receives messages from the `request_handler` used to
+// construct the `Controller, and delivers the host's desired responses to SP
+// request.
+//
+// These are serialized and sent over the contained UDP socket to the multicast
+// address defined in `transceiver_messages::ADDR`.
+//
+// This task also listens for incoming messages on the UDP socket from the SP.
+// These are deserialized and sanity checked. (Obvious failures result in an
+// error being sent back immediately.) Assuming they seem reasonable, then they
+// are dispatched as follows:
+//
+// - Requests from the SP are sent to the request handler, via
+// `incoming_request_tx.
+// - Responses to our own initiated requests are sent back on a `oneshot`
+// channel, that is sent in the data on `outgoing_request_tx`.
+async fn io_loop(
+    log: Logger,
+    socket: UdpSocket,
+    mut outgoing_request_rx: mpsc::Receiver<OutstandingHostRequest>,
+    mut outgoing_response_rx: mpsc::Receiver<HostRpcResponse>,
+    incoming_request_tx: mpsc::Sender<SpRpcRequest>,
+) {
+    let mut recv_buf = [0u8; MAX_PAYLOAD_SIZE + Message::MAX_SIZE];
+    let mut send_buf = recv_buf.clone();
+    let peer_addr = SocketAddrV6::new(Ipv6Addr::from(ADDR), PORT, 0, 0);
+
+    // An outstanding request that has not yet been completed.
+    //
+    // We're accepting requests for submission on `outgoing_request_rx`.
+    // However, once we dequeue that, we still want to block further requests
+    // from being processed. `tokio::sync::mpsc::Receiver` lacks a peek method,
+    // otherwise we'd use that.
+    //
+    // We dequeue the request and store it here. The main loop below contains
+    // if-statements on several of the `tokio::select!` branches, specifically
+    // those related to waiting for new messages on `outgoing_request_rx`. The
+    // effect is that we only wait for new outgoing responses if we're not
+    // currently processing one.
+    let mut outstanding_request: Option<OutstandingHostRequest> = None;
+
+    loop {
+        // We also need to resend an outstanding request, as long as there is
+        // one. This future is recreated on each pass through the loop.
+        let retry_timeout = if let Some(req) = &outstanding_request {
+            sleep_until(req.last_sent + RESEND_INTERVAL)
+        } else {
+            // NOTE: This will never be polled, but the future is evaluated in
+            // each branch of `tokio::select!`, even if it's eventually disabled
+            // by the condition on it.
+            sleep_until(Instant::now() + RESEND_INTERVAL)
+        };
+
+        tokio::select! {
+            // Poll for outgoing requests, but only if we don't already _have_
+            // an outstanding request.
+            maybe_request = outgoing_request_rx.recv(), if outstanding_request.is_none() => {
+
+                // We only get `None` if the sender is closed, meaning the task
+                // holding that side exited. Nothing else will come down this
+                // channel, and things are likely borked. Bail out.
+                let request = match maybe_request {
+                    Some(r) => r,
+                    None => {
+                        debug!(log, "outgoing response channel closed, exiting");
+                        return;
+                    }
+                };
+                debug!(log, "received outgoing request: {request:?}");
+
+                // Store the outstanding request, sanity-checking that we really
+                // didn't have a prior one.
+                let old = outstanding_request.replace(request);
+                assert!(
+                    old.is_none(),
+                    "dequeued a new request while one is already outstanding!",
+                );
+
+                let request = outstanding_request.as_mut().unwrap();
+                match send_outgoing_request(&socket, &peer_addr, request, &mut send_buf).await {
+                    Ok(n) => debug!(log, "sent message"; "message" => ?request, "n_bytes" => n),
+                    Err(e) => error!(log, "failed to send message"; "reason" => ?e),
+                }
+            }
+
+            // If we _do_ have an outstanding request, we need to resend it
+            // periodically until we get a response. Wait for up to the resend
+            // interval of inactivity, and then possibly retry.
+            _ = retry_timeout, if outstanding_request.is_some() => {
+                debug!(log, "timed out without response, retrying");
+                let request = outstanding_request.as_mut().unwrap();
+                send_outgoing_request(&socket, &peer_addr, request, &mut send_buf).await.unwrap();
+                info!(log, "resent message");
+            }
+
+            // Poll for outgoing responses we need to send.
+            maybe_response = outgoing_response_rx.recv() => {
+                let response = match maybe_response {
+                    Some(r) => r,
+                    None => {
+                        debug!(log, "outgoing response channel closed, exiting");
+                        return;
+                    }
+                };
+                // TODO-implement
+                debug!(log, "outgoing response: {response:?}");
+            }
+
+            // Poll for incoming packets.
+            res = socket.recv_from(&mut recv_buf) => {
+                let (n_bytes, peer) = match res {
+                    Err(e) => {
+                        error!(log, "I/O error receiving UDP packet: {e:?}");
+                        continue;
+                    }
+                    Ok((n_bytes, peer)) => (n_bytes, peer),
+                };
+
+                // Deserialize the message itself.
+                let (message, remainder): (Message, _) = match hubpack::deserialize(&recv_buf) {
+                    Err(e) => {
+                        error!(
+                            log,
+                            "failed to deserialize message";
+                            "reason" => ?e,
+                            "peer" => peer,
+                            "n_bytes" => n_bytes,
+                        );
+                        continue;
+                    }
+                    Ok((msg, remainder)) => (msg, remainder),
+                };
+                debug!(log, "message from peer"; "peer" => peer, "message" => ?message);
+
+                // Sanity check the protocol version.
+                if message.header.version != message::version::V1 {
+                    if let Err(e) = send_version_mismatch(&log, &socket, &peer, &message.header, &message.modules).await {
+                        error!(
+                            log,
+                            "failed to send version mismatch";
+                            "reason" => ?e,
+                            "peer" => peer
+                        );
+                    }
+                    continue;
+                }
+
+                // Sanity check that the message could possibly be meant for us.
+                //
+                // We never expect these message types to be sent to us.
+                if matches!(message.body, MessageBody::HostRequest(_) | MessageBody::HostResponse(_)) {
+                    warn!(log, "wrong message type"; "peer" => peer);
+                    send_protocol_error(&log, &socket, &peer, &message.header, &message.modules).await;
+                    continue;
+                }
+
+                // Check that we have data, if the message is supposed to
+                // contain it.
+                let expected_len = message.expected_data_len();
+                let data = if expected_len > 0  {
+                    if remainder.len() < expected_len {
+                        warn!(
+                            log,
+                            "message did not contain expected data";
+                            "expected_len" => expected_len,
+                            "actual_len" => remainder.len(),
+                            "peer" => peer,
+                        );
+                        send_protocol_error(&log, &socket, &peer, &message.header, &message.modules).await;
+                        continue;
+                    }
+                    Some(remainder[..expected_len].to_vec())
+                } else {
+                    None
+                };
+
+                // If this is a request, let's dispatch to the request handler
+                // channel.
+                if matches!(message.body, MessageBody::SpRequest(_)) {
+                    let request = SpRpcRequest {
+                        message,
+                        data,
+                    };
+                    incoming_request_tx.send(request).await.unwrap();
+                    continue;
+                }
+
+                // This is a response, possibly for our outstanding request.
+                if let Some(request) = outstanding_request.take() {
+                    // Check if this is for our current outstanding request.
+                    if request.request.message.header.message_id != message.header.message_id {
+                        warn!(
+                            log,
+                            "received response for message that is not outstanding";
+                            "message" => ?message,
+                            "outstanding_message_id" => request.request.message.header.message_id,
+                            "peer" => peer,
+                        );
+                        continue;
+                    }
+
+                    // We have a valid response!
+                    let response = SpRpcResponse { message, data };
+                    request.response_tx.send(Ok(response)).unwrap();
+                } else {
+                    // We have no outstanding request.
+                    //
+                    // There are a lot of reasons this might be the case, such
+                    // as a duplicate response from the SP for a previous
+                    // request. It's not obvious what to do here, but for now,
+                    // let's log and drop the message.
+                    warn!(
+                        log,
+                        "received response without an outstanding request";
+                        "message" => ?message,
+                        "peer" => peer,
+                    );
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+async fn send_protocol_error(
+    log: &Logger,
+    socket: &UdpSocket,
+    peer: &SocketAddr,
+    header: &Header,
+    modules: &ModuleId,
+) {
+    error!(log, "Protocol error");
+    let err = MessageError::ProtocolError;
+    let message = Message {
+        header: *header,
+        modules: *modules,
+        body: MessageBody::HostResponse(HostResponse::Error(err)),
+    };
+    let mut buf = [0u8; Message::MAX_SIZE];
+    hubpack::serialize(&mut buf, &message).unwrap();
+    match socket.send_to(&buf, peer).await {
+        Err(e) => {
+            error!(
+                log,
+                "failed to send protocol error";
+                "reason" => ?e,
+                "peer" => peer
+            );
+        }
+        Ok(n_bytes) => assert_eq!(n_bytes, Message::MAX_SIZE),
+    }
+}
+
+async fn send_version_mismatch(
+    log: &Logger,
+    socket: &UdpSocket,
+    peer: &SocketAddr,
+    header: &Header,
+    modules: &ModuleId,
+) -> Result<(), Error> {
+    error!(
+        log,
+        "Mismatched protocol versions";
+        "expected" => message::version::V1,
+        "actual" => header.version,
+    );
+    let err = MessageError::VersionMismatch {
+        expected: message::version::V1,
+        actual: header.version,
+    };
+    let message = Message {
+        header: *header,
+        modules: *modules,
+        body: MessageBody::HostResponse(HostResponse::Error(err)),
+    };
+    let mut buf = [0u8; Message::MAX_SIZE];
+    hubpack::serialize(&mut buf, &message).unwrap();
+    let n_bytes = socket.send_to(&buf, peer).await?;
+    assert_eq!(n_bytes, Message::MAX_SIZE);
+    Ok(())
+}
+
+// Send a request from the host to the SP, returning the number of bytes sent.
+async fn send_outgoing_request(
+    socket: &UdpSocket,
+    peer: &SocketAddrV6,
+    request: &mut OutstandingHostRequest,
+    buf: &mut [u8],
+) -> Result<usize, Error> {
+    let mut msg_size = match hubpack::serialize(buf, &request.request.message) {
+        Ok(n) => n,
+        Err(e) => return Err(Error::SerDes(e)),
+    };
+    if let Some(data) = &request.request.data {
+        buf[msg_size..data.len()].copy_from_slice(data);
+        msg_size += data.len();
+    }
+    let n_bytes = socket.send_to(&buf[..msg_size], peer).await?;
+    assert_eq!(n_bytes, msg_size);
+    request.last_sent = Instant::now();
+    Ok(n_bytes)
+}
+
+async fn request_loop<H, F>(
+    log: Logger,
+    mut incoming_request_rx: mpsc::Receiver<SpRpcRequest>,
+    outgoing_response_tx: mpsc::Sender<HostRpcResponse>,
+    request_handler: H,
+) where
+    H: Fn(SpRpcRequest) -> F + Send + Sync + 'static,
+    F: Future<Output = Result<HostRpcResponse, Error>> + Send,
+{
+    loop {
+        let incoming_request = incoming_request_rx.recv().await.unwrap();
+        info!(log, "Incoming request {incoming_request:?}");
+        match request_handler(incoming_request).await {
+            Ok(response) => outgoing_response_tx.send(response).await.unwrap(),
+            Err(e) => error!(log, "request handler failed: {e:?}"),
+        }
+    }
+}

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -13,6 +13,7 @@ use slog::info;
 use slog::warn;
 use slog::Logger;
 use std::future::Future;
+use std::net::IpAddr;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
 use std::net::SocketAddrV6;
@@ -23,8 +24,8 @@ use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-use tokio::time::sleep_until;
-use tokio::time::Instant;
+use tokio::time::interval;
+use tokio::time::Interval;
 use transceiver_messages::message;
 use transceiver_messages::message::Header;
 use transceiver_messages::message::HostRequest;
@@ -38,6 +39,15 @@ use transceiver_messages::ModuleId;
 use transceiver_messages::ADDR;
 use transceiver_messages::MAX_PAYLOAD_SIZE;
 use transceiver_messages::PORT;
+
+#[usdt::provider(provider = "xcvr__ctl")]
+mod probes {
+    fn packet__received(peer: IpAddr, n_bytes: usize) {}
+    fn packet__sent(peer: IpAddr, n_bytes: usize) {}
+    fn message__received(peer: IpAddr, message: &Message) {}
+    fn message__sent(peer: IpAddr, message: &Message) {}
+    fn bad__message(peer: IpAddr, reason: &str) {}
+}
 
 /// An error related to managing the transceivers.
 #[derive(Debug, thiserror::Error)]
@@ -92,8 +102,6 @@ struct OutstandingHostRequest {
     request: HostRpcRequest,
     // The channel on which the eventual reply will be sent.
     response_tx: oneshot::Sender<Result<SpRpcResponse, Error>>,
-    // The time we last sent the request, used during retries.
-    last_sent: Instant,
 }
 
 // We limit ourselves to a single outstanding request in either direction at
@@ -137,13 +145,21 @@ impl Controller {
         H: Fn(SpRpcRequest) -> F + Send + Sync + 'static,
         F: Future<Output = Result<HostRpcResponse, Error>> + Send,
     {
+        if let Err(e) = usdt::register_probes() {
+            warn!(log, "failed to register DTrace probes"; "reason" => ?e);
+        }
+
         // TODO-correctness We probably want to accept a specific address as
         // part of the construction of this object.
+        // TODO-completeness: Need to set the scope_id here based on the
+        // interface we expect to use.
         let local_addr = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, PORT, 0, 0);
         let socket = UdpSocket::bind(local_addr).await?;
 
         // Make sure we receive addresses sent to the multicast address we use
         // for the protocol, but not those sent by us.
+        // TODO-completeness: Need to set the scope_id here based on the
+        // interface we expect to use.
         socket.join_multicast_v6(&Ipv6Addr::from(ADDR), 0)?;
         socket.set_multicast_loop_v6(false)?;
 
@@ -164,18 +180,15 @@ impl Controller {
         // The I/O task handles the actual network I/O, reading and writing UDP
         // packets in both directions.
         let io_log = log.new(slog::o!("task" => "io"));
+        let io_loop = IoLoop::new(
+            io_log,
+            socket,
+            outgoing_request_rx,
+            outgoing_response_rx,
+            incoming_request_tx,
+        );
         let io_task = tokio::spawn(async move {
-            io_loop(
-                io_log,
-                socket,
-                // For receiving requests sent from self.
-                outgoing_request_rx,
-                // For receiving responses sent from request-handler.
-                outgoing_response_rx,
-                // For sending requests from network to self.
-                incoming_request_tx,
-            )
-            .await;
+            io_loop.run().await;
         });
 
         // The request task runs the user-supplied request handler, receiving
@@ -253,7 +266,7 @@ impl Controller {
             .chunks_exact(usize::from(read.len()))
             .map(Vec::from)
             .collect::<Vec<_>>();
-        assert_eq!(data.len(), modules.n_transceivers());
+        assert_eq!(data.len(), modules.selected_transceiver_count());
         Ok(data)
     }
 
@@ -263,7 +276,6 @@ impl Controller {
         let outstanding_request = OutstandingHostRequest {
             request,
             response_tx,
-            last_sent: Instant::now(),
         };
         self.outgoing_request_tx
             .send(outstanding_request)
@@ -274,316 +286,369 @@ impl Controller {
 }
 
 const RESEND_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_PACKET_SIZE: usize = MAX_PAYLOAD_SIZE + Message::MAX_SIZE;
 
-// Main IO loop for communicating with the SP.
-//
-// This task is responsible for accepting messages from the host for delivery to
-// the SP (outgoing) and those from the SP to the host (incoming). The outgoing
-// messages are accepted from two channels:
-//
-// - `outgoing_request_rx` receives messages from the `Controller` object
-// itself, as part of the implementation of its public API.
-// - `outgoing_response_rx` receives messages from the `request_handler` used to
-// construct the `Controller, and delivers the host's desired responses to SP
-// request.
-//
-// These are serialized and sent over the contained UDP socket to the multicast
-// address defined in `transceiver_messages::ADDR`.
-//
-// This task also listens for incoming messages on the UDP socket from the SP.
-// These are deserialized and sanity checked. (Obvious failures result in an
-// error being sent back immediately.) Assuming they seem reasonable, then they
-// are dispatched as follows:
-//
-// - Requests from the SP are sent to the request handler, via
-// `incoming_request_tx.
-// - Responses to our own initiated requests are sent back on a `oneshot`
-// channel, that is sent in the data on `outgoing_request_tx`.
-async fn io_loop(
+// A POD type holding the data we need for the main I/O loop. See `IoLoop::run`
+// for details.
+#[derive(Debug)]
+struct IoLoop {
     log: Logger,
     socket: UdpSocket,
-    mut outgoing_request_rx: mpsc::Receiver<OutstandingHostRequest>,
-    mut outgoing_response_rx: mpsc::Receiver<HostRpcResponse>,
+    peer_addr: SocketAddrV6,
+    outstanding_request: Option<OutstandingHostRequest>,
+    outgoing_request_rx: mpsc::Receiver<OutstandingHostRequest>,
+    outgoing_response_rx: mpsc::Receiver<HostRpcResponse>,
     incoming_request_tx: mpsc::Sender<SpRpcRequest>,
-) {
-    let mut recv_buf = [0u8; MAX_PAYLOAD_SIZE + Message::MAX_SIZE];
-    let mut send_buf = recv_buf.clone();
-    let peer_addr = SocketAddrV6::new(Ipv6Addr::from(ADDR), PORT, 0, 0);
+    resend: Interval,
+}
 
-    // An outstanding request that has not yet been completed.
-    //
-    // We're accepting requests for submission on `outgoing_request_rx`.
-    // However, once we dequeue that, we still want to block further requests
-    // from being processed. `tokio::sync::mpsc::Receiver` lacks a peek method,
-    // otherwise we'd use that.
-    //
-    // We dequeue the request and store it here. The main loop below contains
-    // if-statements on several of the `tokio::select!` branches, specifically
-    // those related to waiting for new messages on `outgoing_request_rx`. The
-    // effect is that we only wait for new outgoing responses if we're not
-    // currently processing one.
-    let mut outstanding_request: Option<OutstandingHostRequest> = None;
+impl IoLoop {
+    fn new(
+        log: Logger,
+        socket: UdpSocket,
+        outgoing_request_rx: mpsc::Receiver<OutstandingHostRequest>,
+        outgoing_response_rx: mpsc::Receiver<HostRpcResponse>,
+        incoming_request_tx: mpsc::Sender<SpRpcRequest>,
+    ) -> Self {
+        Self {
+            log,
+            socket,
+            peer_addr: SocketAddrV6::new(Ipv6Addr::from(ADDR), PORT, 0, 0),
+            outstanding_request: None,
+            outgoing_request_rx,
+            outgoing_response_rx,
+            incoming_request_tx,
+            resend: interval(RESEND_INTERVAL),
+        }
+    }
 
-    loop {
-        // We also need to resend an outstanding request, as long as there is
-        // one. This future is recreated on each pass through the loop.
-        let retry_timeout = if let Some(req) = &outstanding_request {
-            sleep_until(req.last_sent + RESEND_INTERVAL)
+    // Send an outgoing request.
+    //
+    // Panics if there is no outstanding request.
+    async fn send_outgoing_request(&self, tx_buf: &mut [u8]) {
+        // Safety: Serialization can only fail in a few constrained
+        // circumstances, such as a buffer overrun or unsupported types. None of
+        // those apply here, so we just unwrap in that direction.
+        let request = self.outstanding_request.as_ref().unwrap();
+        let data_start = hubpack::serialize(tx_buf, &request.request.message).unwrap();
+        let msg_size = if let Some(data) = &request.request.data {
+            let data_end = data_start + data.len();
+            tx_buf[data_start..data_end].copy_from_slice(data);
+            data_end
         } else {
-            // NOTE: This will never be polled, but the future is evaluated in
-            // each branch of `tokio::select!`, even if it's eventually disabled
-            // by the condition on it.
-            sleep_until(Instant::now() + RESEND_INTERVAL)
+            data_start
         };
-
-        tokio::select! {
-            // Poll for outgoing requests, but only if we don't already _have_
-            // an outstanding request.
-            maybe_request = outgoing_request_rx.recv(), if outstanding_request.is_none() => {
-
-                // We only get `None` if the sender is closed, meaning the task
-                // holding that side exited. Nothing else will come down this
-                // channel, and things are likely borked. Bail out.
-                let request = match maybe_request {
-                    Some(r) => r,
-                    None => {
-                        debug!(log, "outgoing response channel closed, exiting");
-                        return;
-                    }
-                };
-                debug!(log, "received outgoing request: {request:?}");
-
-                // Store the outstanding request, sanity-checking that we really
-                // didn't have a prior one.
-                let old = outstanding_request.replace(request);
-                assert!(
-                    old.is_none(),
-                    "dequeued a new request while one is already outstanding!",
+        match self
+            .socket
+            .send_to(&tx_buf[..msg_size], &self.peer_addr)
+            .await
+        {
+            Err(e) => {
+                error!(
+                    self.log,
+                    "failed to send outgoing request";
+                    "peer" => ?self.peer_addr,
+                    "reason" => ?e,
                 );
-
-                let request = outstanding_request.as_mut().unwrap();
-                match send_outgoing_request(&socket, &peer_addr, request, &mut send_buf).await {
-                    Ok(n) => debug!(log, "sent message"; "message" => ?request, "n_bytes" => n),
-                    Err(e) => error!(log, "failed to send message"; "reason" => ?e),
-                }
             }
-
-            // If we _do_ have an outstanding request, we need to resend it
-            // periodically until we get a response. Wait for up to the resend
-            // interval of inactivity, and then possibly retry.
-            _ = retry_timeout, if outstanding_request.is_some() => {
-                debug!(log, "timed out without response, retrying");
-                let request = outstanding_request.as_mut().unwrap();
-                send_outgoing_request(&socket, &peer_addr, request, &mut send_buf).await.unwrap();
-                info!(log, "resent message");
+            Ok(n_bytes) => {
+                assert_eq!(n_bytes, msg_size);
+                debug!(
+                    self.log,
+                    "sent outgoing request";
+                    "peer" => ?self.peer_addr,
+                    "message" => ?request.request.message,
+                );
+                probes::packet__sent!(|| {
+                    let peer = IpAddr::V6(*self.peer_addr.ip());
+                    (peer, n_bytes)
+                });
+                probes::message__sent!(|| {
+                    let peer = IpAddr::V6(*self.peer_addr.ip());
+                    (peer, &request.request.message)
+                });
             }
+        }
+    }
 
-            // Poll for outgoing responses we need to send.
-            maybe_response = outgoing_response_rx.recv() => {
-                let response = match maybe_response {
-                    Some(r) => r,
-                    None => {
-                        debug!(log, "outgoing response channel closed, exiting");
-                        return;
-                    }
-                };
-                // TODO-implement
-                debug!(log, "outgoing response: {response:?}");
+    async fn send_protocol_error(
+        &self,
+        peer: &SocketAddr,
+        header: Header,
+        modules: ModuleId,
+        tx_buf: &mut [u8],
+    ) {
+        let body = MessageBody::HostResponse(HostResponse::Error(MessageError::ProtocolError));
+        let message = Message {
+            header,
+            modules,
+            body,
+        };
+        let serialized_len = hubpack::serialize(tx_buf, &message).unwrap();
+        match self.socket.send_to(&tx_buf[..serialized_len], peer).await {
+            Err(e) => {
+                error!(
+                    self.log,
+                    "failed to send protocol error";
+                    "reason" => ?e,
+                    "peer" => peer
+                );
             }
+            Ok(n_bytes) => {
+                debug!(
+                    self.log,
+                    "sent protocol error";
+                    "peer" => ?self.peer_addr,
+                    "message" => ?message,
+                );
+                probes::packet__sent!(|| {
+                    let peer = IpAddr::V6(*self.peer_addr.ip());
+                    (peer, n_bytes)
+                });
+                probes::message__sent!(|| {
+                    let peer = IpAddr::V6(*self.peer_addr.ip());
+                    (peer, &message)
+                });
+                assert_eq!(n_bytes, serialized_len);
+            }
+        }
+    }
 
-            // Poll for incoming packets.
-            res = socket.recv_from(&mut recv_buf) => {
-                let (n_bytes, peer) = match res {
-                    Err(e) => {
-                        error!(log, "I/O error receiving UDP packet: {e:?}");
-                        continue;
-                    }
-                    Ok((n_bytes, peer)) => (n_bytes, peer),
-                };
+    // Main IO loop for communicating with the SP.
+    //
+    // This task is responsible for accepting messages from the host for delivery to
+    // the SP (outgoing) and those from the SP to the host (incoming). The outgoing
+    // messages are accepted from two channels:
+    //
+    // - `self.outgoing_request_rx` receives messages from the `Controller`
+    // object itself, as part of the implementation of its public API.
+    // - `self.outgoing_response_rx` receives messages from the
+    // `request_handler` used to construct the `Controller`, and delivers the
+    // host's desired responses to a SP request.
+    //
+    // These are serialized and sent over the contained UDP socket to the multicast
+    // address defined in `transceiver_messages::ADDR`.
+    //
+    // This task also listens for incoming messages on the UDP socket from the SP.
+    // These are deserialized and sanity checked. (Obvious failures result in an
+    // error being sent back immediately.) Assuming they seem reasonable, then they
+    // are dispatched as follows:
+    //
+    // - Requests from the SP are sent to the request handler, via
+    // `incoming_request_tx`.
+    // - Responses to our own initiated requests are sent back on a `oneshot`
+    // channel, that is sent in the data on `outgoing_request_tx`.
+    async fn run(mut self) {
+        let mut rx_buf = [0; MAX_PACKET_SIZE];
+        let mut tx_buf = [0; MAX_PACKET_SIZE];
 
-                // Deserialize the message itself.
-                let (message, remainder): (Message, _) = match hubpack::deserialize(&recv_buf) {
-                    Err(e) => {
-                        error!(
-                            log,
-                            "failed to deserialize message";
-                            "reason" => ?e,
-                            "peer" => peer,
-                            "n_bytes" => n_bytes,
-                        );
-                        continue;
-                    }
-                    Ok((msg, remainder)) => (msg, remainder),
-                };
-                debug!(log, "message from peer"; "peer" => peer, "message" => ?message);
+        loop {
+            tokio::select! {
+                // Poll for outgoing requests, but only if we don't already _have_
+                // an outstanding request.
+                maybe_request = self.outgoing_request_rx.recv(), if self.outstanding_request.is_none() => {
 
-                // Sanity check the protocol version.
-                if message.header.version != message::version::V1 {
-                    if let Err(e) = send_version_mismatch(&log, &socket, &peer, &message.header, &message.modules).await {
-                        error!(
-                            log,
-                            "failed to send version mismatch";
-                            "reason" => ?e,
-                            "peer" => peer
-                        );
-                    }
-                    continue;
-                }
-
-                // Sanity check that the message could possibly be meant for us.
-                //
-                // We never expect these message types to be sent to us.
-                if matches!(message.body, MessageBody::HostRequest(_) | MessageBody::HostResponse(_)) {
-                    warn!(log, "wrong message type"; "peer" => peer);
-                    send_protocol_error(&log, &socket, &peer, &message.header, &message.modules).await;
-                    continue;
-                }
-
-                // Check that we have data, if the message is supposed to
-                // contain it.
-                let expected_len = message.expected_data_len();
-                let data = if expected_len > 0  {
-                    if remainder.len() < expected_len {
-                        warn!(
-                            log,
-                            "message did not contain expected data";
-                            "expected_len" => expected_len,
-                            "actual_len" => remainder.len(),
-                            "peer" => peer,
-                        );
-                        send_protocol_error(&log, &socket, &peer, &message.header, &message.modules).await;
-                        continue;
-                    }
-                    Some(remainder[..expected_len].to_vec())
-                } else {
-                    None
-                };
-
-                // If this is a request, let's dispatch to the request handler
-                // channel.
-                if matches!(message.body, MessageBody::SpRequest(_)) {
-                    let request = SpRpcRequest {
-                        message,
-                        data,
+                    // We only get `None` if the sender is closed, meaning the task
+                    // holding that side exited. Nothing else will come down this
+                    // channel, and things are likely borked. Bail out.
+                    let request = match maybe_request {
+                        Some(r) => r,
+                        None => {
+                            debug!(self.log, "outgoing response channel closed, exiting");
+                            return;
+                        }
                     };
-                    incoming_request_tx.send(request).await.unwrap();
-                    continue;
+                    debug!(self.log, "received outgoing request: {request:?}");
+
+                    // Store the outstanding request, sanity-checking that we really
+                    // didn't have a prior one.
+                    let old = self.outstanding_request.replace(request);
+                    assert!(
+                        old.is_none(),
+                        "dequeued a new request while one is already outstanding!",
+                    );
+                    self.send_outgoing_request(&mut tx_buf).await;
+                    self.resend.reset();
                 }
 
-                // This is a response, possibly for our outstanding request.
-                if let Some(request) = outstanding_request.take() {
-                    // Check if this is for our current outstanding request.
-                    if request.request.message.header.message_id != message.header.message_id {
-                        warn!(
-                            log,
-                            "received response for message that is not outstanding";
+                // If we _do_ have an outstanding request, we need to resend it
+                // periodically until we get a response. Wait for up to the resend
+                // interval of inactivity, and then possibly retry.
+                _ = self.resend.tick(), if self.outstanding_request.is_some() => {
+                    debug!(self.log, "timed out without response, retrying");
+                    self.send_outgoing_request(&mut tx_buf).await;
+                    self.resend.reset();
+                }
+
+                // Poll for outgoing responses we need to send.
+                maybe_response = self.outgoing_response_rx.recv() => {
+                    let response = match maybe_response {
+                        Some(r) => r,
+                        None => {
+                            debug!(self.log, "outgoing response channel closed, exiting");
+                            return;
+                        }
+                    };
+                    // TODO-implement
+                    debug!(self.log, "outgoing response: {response:?}");
+                }
+
+                // Poll for incoming packets.
+                res = self.socket.recv_from(&mut rx_buf) => {
+                    let (n_bytes, peer) = match res {
+                        Err(e) => {
+                            error!(self.log, "I/O error receiving UDP packet: {e:?}");
+                            continue;
+                        }
+                        Ok((n_bytes, peer)) => {
+                            debug!(
+                                self.log,
+                                "packet received";
+                                "n_bytes" => n_bytes,
+                                "peer" => peer,
+                            );
+                            probes::packet__received!(|| (peer.ip(), n_bytes));
+                            (n_bytes, peer)
+                        }
+                    };
+
+                    // Deserialize the message itself.
+                    let (message, remainder): (Message, _) = match hubpack::deserialize(&rx_buf) {
+                        Err(e) => {
+                            // We've failed to deserialize the message. We'll
+                            // not send any failure back to the peer, since we
+                            // have no information about what kind of message
+                            // this is. However, we'll deserialize the header
+                            // (which should never fail) and emit a log message.
+                            let (header, _): (Header, _) = hubpack::deserialize(&rx_buf).unwrap();
+                            error!(
+                                self.log,
+                                "failed to deserialize message";
+                                "reason" => ?e,
+                                "peer" => peer,
+                                "n_bytes" => n_bytes,
+                                "header" => ?header,
+                            );
+                            probes::bad__message!(|| {
+                                (peer.ip(), format!("deserialization failure: {e:?}"))
+                            });
+                            continue;
+                        }
+                        Ok((msg, remainder)) => (msg, remainder),
+                    };
+                    debug!(
+                        self.log,
+                        "message from peer";
+                        "peer" => peer,
+                        "message" => ?message
+                    );
+                    probes::message__received!(|| (peer.ip(), &message));
+
+                    // Sanity check the protocol version.
+                    if message.header.version != message::version::V1 {
+                        // If the version does not match, we're choosing to drop
+                        // the packet rather than reply with a version mismatch
+                        // error. Without a matching version, we can't really
+                        // trust the message kind we have deserialized, so won't
+                        // be able to reliably send protocol errors.
+                        debug!(
+                            self.log,
+                            "deserialized message with incorrect version";
+                            "expected" => message::version::V1,
+                            "actual" => message.header.version,
+                            "peer" => peer,
+                        );
+                        probes::bad__message!(|| {
+                            (
+                                peer.ip(),
+                                format!(
+                                    "incorrect version: expected {}, actual {}",
+                                    message::version::V1,
+                                    message.header.version,
+                                ),
+                            )
+                        });
+                        continue;
+                    }
+
+                    // Sanity check that the message could possibly be meant for us.
+                    //
+                    // We never expect these message types to be sent to us.
+                    if matches!(message.body, MessageBody::HostRequest(_) | MessageBody::HostResponse(_)) {
+                        debug!(self.log, "wrong message type"; "peer" => peer);
+                        probes::bad__message!(|| (peer.ip(), "wrong message type"));
+                        self.send_protocol_error(&peer, message.header, message.modules, &mut tx_buf).await;
+                        continue;
+                    }
+
+                    // Check that we have data, if the message is supposed to
+                    // contain it.
+                    let expected_len = message.expected_data_len();
+                    let data = if expected_len > 0  {
+                        if remainder.len() < expected_len {
+                            error!(
+                                self.log,
+                                "message did not contain expected data";
+                                "expected_len" => expected_len,
+                                "actual_len" => remainder.len(),
+                                "peer" => peer,
+                            );
+                            probes::bad__message!(|| (peer.ip(), "message missing data"));
+                            self.send_protocol_error(&peer, message.header, message.modules, &mut tx_buf).await;
+                            continue;
+                        }
+                        Some(remainder[..expected_len].to_vec())
+                    } else {
+                        None
+                    };
+
+                    // If this is a request, let's dispatch to the request handler
+                    // channel.
+                    if matches!(message.body, MessageBody::SpRequest(_)) {
+                        let request = SpRpcRequest {
+                            message,
+                            data,
+                        };
+                        self.incoming_request_tx.send(request).await.unwrap();
+                        continue;
+                    }
+
+                    // This is a response, possibly for our outstanding request.
+                    if let Some(request) = self.outstanding_request.take() {
+                        // Check if this is for our current outstanding request.
+                        if request.request.message.header.message_id != message.header.message_id {
+                            debug!(
+                                self.log,
+                                "received response for message that is not outstanding";
+                                "message" => ?message,
+                                "outstanding_message_id" => request.request.message.header.message_id,
+                                "peer" => peer,
+                            );
+                            continue;
+                        }
+
+                        // We have a valid response!
+                        let response = SpRpcResponse { message, data };
+                        request.response_tx.send(Ok(response)).unwrap();
+                    } else {
+                        // We have no outstanding request.
+                        //
+                        // There are a lot of reasons this might be the case, such
+                        // as a duplicate response from the SP for a previous
+                        // request. It's not obvious what to do here, but for now,
+                        // let's log and drop the message.
+                        debug!(
+                            self.log,
+                            "received response without an outstanding request";
                             "message" => ?message,
-                            "outstanding_message_id" => request.request.message.header.message_id,
                             "peer" => peer,
                         );
                         continue;
                     }
-
-                    // We have a valid response!
-                    let response = SpRpcResponse { message, data };
-                    request.response_tx.send(Ok(response)).unwrap();
-                } else {
-                    // We have no outstanding request.
-                    //
-                    // There are a lot of reasons this might be the case, such
-                    // as a duplicate response from the SP for a previous
-                    // request. It's not obvious what to do here, but for now,
-                    // let's log and drop the message.
-                    warn!(
-                        log,
-                        "received response without an outstanding request";
-                        "message" => ?message,
-                        "peer" => peer,
-                    );
-                    continue;
                 }
             }
         }
     }
-}
-
-async fn send_protocol_error(
-    log: &Logger,
-    socket: &UdpSocket,
-    peer: &SocketAddr,
-    header: &Header,
-    modules: &ModuleId,
-) {
-    error!(log, "Protocol error");
-    let err = MessageError::ProtocolError;
-    let message = Message {
-        header: *header,
-        modules: *modules,
-        body: MessageBody::HostResponse(HostResponse::Error(err)),
-    };
-    let mut buf = [0u8; Message::MAX_SIZE];
-    hubpack::serialize(&mut buf, &message).unwrap();
-    match socket.send_to(&buf, peer).await {
-        Err(e) => {
-            error!(
-                log,
-                "failed to send protocol error";
-                "reason" => ?e,
-                "peer" => peer
-            );
-        }
-        Ok(n_bytes) => assert_eq!(n_bytes, Message::MAX_SIZE),
-    }
-}
-
-async fn send_version_mismatch(
-    log: &Logger,
-    socket: &UdpSocket,
-    peer: &SocketAddr,
-    header: &Header,
-    modules: &ModuleId,
-) -> Result<(), Error> {
-    error!(
-        log,
-        "Mismatched protocol versions";
-        "expected" => message::version::V1,
-        "actual" => header.version,
-    );
-    let err = MessageError::VersionMismatch {
-        expected: message::version::V1,
-        actual: header.version,
-    };
-    let message = Message {
-        header: *header,
-        modules: *modules,
-        body: MessageBody::HostResponse(HostResponse::Error(err)),
-    };
-    let mut buf = [0u8; Message::MAX_SIZE];
-    hubpack::serialize(&mut buf, &message).unwrap();
-    let n_bytes = socket.send_to(&buf, peer).await?;
-    assert_eq!(n_bytes, Message::MAX_SIZE);
-    Ok(())
-}
-
-// Send a request from the host to the SP, returning the number of bytes sent.
-async fn send_outgoing_request(
-    socket: &UdpSocket,
-    peer: &SocketAddrV6,
-    request: &mut OutstandingHostRequest,
-    buf: &mut [u8],
-) -> Result<usize, Error> {
-    let mut msg_size = match hubpack::serialize(buf, &request.request.message) {
-        Ok(n) => n,
-        Err(e) => return Err(Error::SerDes(e)),
-    };
-    if let Some(data) = &request.request.data {
-        buf[msg_size..data.len()].copy_from_slice(data);
-        msg_size += data.len();
-    }
-    let n_bytes = socket.send_to(&buf[..msg_size], peer).await?;
-    assert_eq!(n_bytes, msg_size);
-    request.last_sent = Instant::now();
-    Ok(n_bytes)
 }
 
 async fn request_loop<H, F>(
@@ -595,12 +660,12 @@ async fn request_loop<H, F>(
     H: Fn(SpRpcRequest) -> F + Send + Sync + 'static,
     F: Future<Output = Result<HostRpcResponse, Error>> + Send,
 {
-    loop {
-        let incoming_request = incoming_request_rx.recv().await.unwrap();
+    while let Some(incoming_request) = incoming_request_rx.recv().await {
         info!(log, "Incoming request {incoming_request:?}");
         match request_handler(incoming_request).await {
             Ok(response) => outgoing_response_tx.send(response).await.unwrap(),
             Err(e) => error!(log, "request handler failed: {e:?}"),
         }
     }
+    debug!(log, "request handler channel closed, exiting");
 }

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -5,15 +5,20 @@ edition = "2021"
 
 [dependencies]
 bitflags = "1"
-
-[dependencies.hubpack]
-version = "0.1.0"
+hubpack = "0.1.0"
 
 [dependencies.serde]
 version = "1"
 features = [ "derive" ]
 default-features = false
 
+[dependencies.thiserror]
+version = "1"
+optional = true
+
 [features]
-std = []
+std = [ "dep:thiserror" ]
 default = [ "std" ]
+
+[dev-dependencies]
+thiserror = "1"

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -163,7 +163,7 @@ impl PortMask {
     }
 
     /// Return the number of transceivers addressed by `self.
-    pub const fn n_transceivers(&self) -> usize {
+    pub const fn selected_transceiver_count(&self) -> usize {
         self.0.count_ones() as _
     }
 }
@@ -177,8 +177,8 @@ pub struct ModuleId {
 
 impl ModuleId {
     /// Return the number of transceivers addressed by `self`.
-    pub const fn n_transceivers(&self) -> usize {
-        self.ports.n_transceivers()
+    pub const fn selected_transceiver_count(&self) -> usize {
+        self.ports.selected_transceiver_count()
     }
 }
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -74,6 +74,10 @@ pub enum Error {
     /// Someone sent an unexpected message (e.g. the host sending an SpRequest).
     ProtocolError,
 
+    /// A message expected trailing data, but none was contained in the UDP
+    /// packet.
+    MissingData,
+
     /// The version in the header is unexpected.
     VersionMismatch { expected: u8, actual: u8 },
 }

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -49,7 +49,7 @@ impl Message {
             MessageBody::SpResponse(SpResponse::Read(inner)) => inner.len(),
             _ => 0,
         };
-        self.modules.n_transceivers() * usize::from(bytes_per_xcvr)
+        self.modules.selected_transceiver_count() * usize::from(bytes_per_xcvr)
     }
 }
 


### PR DESCRIPTION
- Adds a `Controller`, the main type which handles the network protocol between the host and SP. This spawns a tokio task for managing the actual UDP socket and for calling the user-supplied request-handler function. These communicate with the main controller via channels. The public API is basically a wrapper converting the data for each function into the right RPC message, and then passing that to the network task for sending and receiving the response.
- Adds a small CLI for running the controller manually. It currently does very little.
- Adds a dumb mock SP, which just responds to memory reads with zeros of the right size.