### PR TITLE
Support for some configuration values

### DIFF
--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -13,6 +13,14 @@ thiserror = "1"
 transceiver-messages = { path = "../messages" }
 usdt = "0.3"
 
+[dependencies.clap]
+version = "4"
+features = [ "derive" ]
+
+[dependencies.nix]
+version = "0.25"
+features = [ "net" ]
+
 [dependencies.slog]
 version = "2"
 features = [ "max_level_trace", "release_max_level_trace" ]

--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -1,8 +1,15 @@
+use clap::Parser;
+use clap::Subcommand;
 use slog::Drain;
+use slog::Level;
+use std::net::Ipv6Addr;
+use std::time::Duration;
+use transceiver_controller::Config;
 use transceiver_controller::Controller;
 use transceiver_controller::Error;
 use transceiver_controller::HostRpcResponse;
 use transceiver_controller::SpRpcRequest;
+use transceiver_messages::message::Status;
 use transceiver_messages::mgmt::sff8636;
 use transceiver_messages::mgmt::MemoryRead;
 use transceiver_messages::Error as MessageError;
@@ -13,11 +20,99 @@ async fn request_handler(_: SpRpcRequest) -> Result<HostRpcResponse, Error> {
     Err(Error::Protocol(MessageError::ProtocolError))
 }
 
+fn parse_xvcr_list(s: &str) -> Result<Vec<u8>, String> {
+    s.split(",")
+        .map(|x| {
+            x.parse()
+                .map_err(|_| String::from("invalid transceiver index"))
+        })
+        .collect()
+}
+
+fn parse_log_level(s: &str) -> Result<Level, String> {
+    s.parse().map_err(|_| String::from("invalid log level"))
+}
+
+#[derive(Parser)]
+struct Args {
+    #[command(subcommand)]
+    cmd: Cmd,
+
+    /// The FPGA whose transceivers to address.
+    #[arg(short, long, default_value_t = 0)]
+    fpga_id: u8,
+
+    /// The comma-separated list of transcievers on the FPGA to address.
+    ///
+    /// The default is all transceivers on an FPGA.
+    #[arg(short, long)]
+    transceivers: Option<String>,
+
+    /// The source IP address on which to listen for messages.
+    #[arg(short, long, default_value_t = Ipv6Addr::UNSPECIFIED)]
+    address: Ipv6Addr,
+
+    /// The source interface on which to listen for messages.
+    #[arg(short, long)]
+    interface: String,
+
+    /// The unicast peer address to assume.
+    ///
+    /// The protocol is normally run using a multicast address, but a single
+    /// peer may optionally be specified.
+    #[arg(short, long)]
+    peer: Option<Ipv6Addr>,
+
+    /// The maximum number of retries before failing a request.
+    #[arg(short, long)]
+    n_retries: Option<usize>,
+
+    /// The retry interval for requests, in milliseconds.
+    #[arg(
+        short,
+        long,
+        default_value_t = 1000,
+        value_parser = clap::value_parser!(u64).range(1..=10000)
+    )]
+    retry_interval: u64,
+
+    /// The log-level.
+    #[arg(
+        short,
+        long,
+        default_value_t = Level::Info,
+        value_parser = parse_log_level
+    )]
+    log_level: Level,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Return the status of the addressed modules, such as presence, power
+    /// enable, and power mode.
+    Status,
+
+    /// Read the lower page of a set of transceiver modules.
+    ReadLower { offset: u8, len: u8 },
+}
+
 #[tokio::main]
 async fn main() {
+    let args = Args::parse();
+    let config = Config {
+        address: args.address,
+        interface: args.interface,
+        peer: args
+            .peer
+            .unwrap_or(Ipv6Addr::from(transceiver_messages::ADDR)),
+        n_retries: args.n_retries,
+        retry_interval: Duration::from_millis(args.retry_interval),
+    };
+
     let decorator = slog_term::TermDecorator::new().build();
     let drain = slog_term::FullFormat::new(decorator).build().fuse();
     let drain = slog_async::Async::new(drain).build().fuse();
+    let drain = slog::LevelFilter::new(drain, args.log_level).fuse();
     let log = slog::Logger::root(drain, slog::o!());
 
     let request_handler_log = log.new(slog::o!("name" => "request_handler"));
@@ -25,17 +120,45 @@ async fn main() {
         slog::info!(request_handler_log, "received sp request"; "message" => ?message);
         async move { request_handler(message).await }
     };
-    let controller = Controller::new(log.clone(), handler).await.unwrap();
-    let read = MemoryRead::new(sff8636::Page::Lower, 0, 4).unwrap();
-    let data = controller
-        .read(
-            ModuleId {
-                fpga_id: 0,
-                ports: PortMask(0b11),
-            },
-            read,
-        )
-        .await
-        .unwrap();
-    slog::info!(log, "data: {:?}", data);
+
+    let ports = args
+        .transceivers
+        .map(|list| PortMask::from_indices(&parse_xvcr_list(&list).unwrap()).unwrap())
+        .unwrap_or_else(|| PortMask::all());
+    let modules = ModuleId {
+        fpga_id: args.fpga_id,
+        ports,
+    };
+    let controller = Controller::new(config, log.clone(), handler).await.unwrap();
+
+    match args.cmd {
+        Cmd::Status => {
+            let status = controller.status(modules).await.unwrap();
+            print_module_status(modules, status);
+        }
+        Cmd::ReadLower { offset, len } => {
+            let read = MemoryRead::new(sff8636::Page::Lower, offset, len).unwrap();
+            let data = controller.read(modules, read).await.unwrap();
+            print_read_data(modules, data);
+        }
+    }
+}
+
+fn print_module_status(modules: ModuleId, status: Vec<Status>) {
+    println!("FPGA\tPort\tStatus");
+    for (port, status) in modules.ports.to_indices().zip(status.into_iter()) {
+        println!("{}\t{port}\t{status:?}", modules.fpga_id);
+    }
+}
+
+fn print_read_data(modules: ModuleId, data: Vec<Vec<u8>>) {
+    println!("FPGA\tPort\tData");
+    for (port, each) in modules.ports.to_indices().zip(data.into_iter()) {
+        let hex_data = each
+            .into_iter()
+            .map(|byte| format!("0x{byte:02x}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        println!("{}\t{port}\t[{hex_data}]", modules.fpga_id);
+    }
 }

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -7,6 +7,9 @@
 //! A host-side control interface to the SP for managing Sidecar transceivers.
 
 use hubpack::SerializedSize;
+use nix::net::if_::if_nametoindex;
+use serde::Deserialize;
+use serde::Serialize;
 use slog::debug;
 use slog::error;
 use slog::info;
@@ -32,6 +35,7 @@ use transceiver_messages::message::HostRequest;
 use transceiver_messages::message::HostResponse;
 use transceiver_messages::message::Message;
 use transceiver_messages::message::MessageBody;
+use transceiver_messages::message::SpResponse;
 use transceiver_messages::message::Status;
 use transceiver_messages::mgmt::MemoryRead;
 use transceiver_messages::Error as MessageError;
@@ -58,8 +62,20 @@ pub enum Error {
     #[error("Network or I/O error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("A serialization error occurred: {0}")]
-    SerDes(hubpack::Error),
+    #[error("Message type requires data, but none provided")]
+    MessageRequiresData,
+
+    #[error("Could not find requested interface")]
+    BadInterface(String),
+
+    #[error("Maximum number of retries ({0}) reached without a response")]
+    MaxRetries(usize),
+
+    #[error(
+        "Read of transceiver module memory failed, \
+        one of the requested transceivers may not be present"
+    )]
+    ReadFailed,
 }
 
 // A request sent from host to SP, possibly with trailing data.
@@ -104,10 +120,46 @@ struct OutstandingHostRequest {
 // We limit ourselves to a single outstanding request in either direction at
 // this point.
 const NUM_OUTSTANDING_REQUESTS: usize = 1;
+const RESEND_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_PACKET_SIZE: usize = MAX_PAYLOAD_SIZE + Message::MAX_SIZE;
+
+const fn default_retry_interval() -> Duration {
+    RESEND_INTERVAL
+}
+
+fn default_peer_addr() -> Ipv6Addr {
+    Ipv6Addr::from(ADDR)
+}
+
+/// Configuration for a `Controller`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Config {
+    /// The address on which to listen for messages.
+    pub address: Ipv6Addr,
+
+    /// The name of the interface on which to listen.
+    pub interface: String,
+
+    /// The IPv6 address to use for communication.
+    ///
+    /// The default is a link-local IPv6 multicast address.
+    #[serde(default = "default_peer_addr")]
+    pub peer: Ipv6Addr,
+
+    /// The interval on which to retry messages that receive no response.
+    #[serde(default = "default_retry_interval")]
+    pub retry_interval: Duration,
+
+    /// The number of retries for a message before failing.
+    #[serde(default)]
+    pub n_retries: Option<usize>,
+}
 
 /// A type for controlling transceiver modules on a Sidecar.
 #[derive(Debug)]
 pub struct Controller {
+    _config: Config,
+    _iface: u32,
     _log: Logger,
     message_id: AtomicU64,
 
@@ -138,7 +190,7 @@ impl Controller {
     /// `request_handler` is a function that yields responses to SP requests. As
     /// requests over the network are received, they'll be passed into the
     /// handler, and the yielded response forwarded back to the SP.
-    pub async fn new<H, F>(log: Logger, request_handler: H) -> Result<Self, Error>
+    pub async fn new<H, F>(config: Config, log: Logger, request_handler: H) -> Result<Self, Error>
     where
         H: Fn(SpRpcRequest) -> F + Send + Sync + 'static,
         F: Future<Output = Result<HostRpcResponse, Error>> + Send,
@@ -147,19 +199,28 @@ impl Controller {
             warn!(log, "failed to register DTrace probes"; "reason" => ?e);
         }
 
-        // TODO-correctness We probably want to accept a specific address as
-        // part of the construction of this object.
-        // TODO-completeness: Need to set the scope_id here based on the
-        // interface we expect to use.
-        let local_addr = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, PORT, 0, 0);
+        let iface = if_nametoindex(config.interface.as_str())
+            .map_err(|_| Error::BadInterface(config.interface.clone()))?;
+        let local_addr = SocketAddrV6::new(config.address, PORT, 0, iface);
         let socket = UdpSocket::bind(local_addr).await?;
+        debug!(
+            log,
+            "bound UDP socket";
+            "interface" => &config.interface,
+            "local_addr" => ?local_addr,
+        );
 
-        // Make sure we receive addresses sent to the multicast address we use
-        // for the protocol, but not those sent by us.
-        // TODO-completeness: Need to set the scope_id here based on the
-        // interface we expect to use.
-        socket.join_multicast_v6(&Ipv6Addr::from(ADDR), 0)?;
+        // Join the group for the multicast protocol address, so that we can
+        // accept requests from the SP in the case it does not have our unicast
+        // address.
+        let multicast_addr = Ipv6Addr::from(ADDR);
+        socket.join_multicast_v6(&multicast_addr, iface)?;
         socket.set_multicast_loop_v6(false)?;
+        debug!(
+            log,
+            "joined IPv6 multicast group";
+            "multicast_addr" => ?multicast_addr,
+        );
 
         // Channel for communicating outgoing requests from this object to the
         // I/O loop. Note that the _responses_ from the I/O loop back to this
@@ -175,12 +236,23 @@ impl Controller {
         // the request-handler task.
         let (incoming_request_tx, incoming_request_rx) = mpsc::channel(NUM_OUTSTANDING_REQUESTS);
 
+        // The multicast peer address for our protocol.
+        //
+        // We can't both `connect` the socket and still `send_to`, which means
+        // we wouldn't be able to send outgoing packets without a unicast
+        // adddress. Pass this address to the IO loop, so we can initiate
+        // requests.
+        let peer_addr = SocketAddrV6::new(config.peer, PORT, 0, iface);
+
         // The I/O task handles the actual network I/O, reading and writing UDP
         // packets in both directions.
         let io_log = log.new(slog::o!("task" => "io"));
         let io_loop = IoLoop::new(
             io_log,
             socket,
+            peer_addr,
+            config.n_retries,
+            config.retry_interval,
             outgoing_request_rx,
             outgoing_response_rx,
             incoming_request_tx,
@@ -188,6 +260,7 @@ impl Controller {
         let io_task = tokio::spawn(async move {
             io_loop.run().await;
         });
+        debug!(log, "spawned IO task");
 
         // The request task runs the user-supplied request handler, receiving
         // valid requests from the I/O task and sending valid responses back.
@@ -203,8 +276,11 @@ impl Controller {
             )
             .await;
         });
+        debug!(log, "spawned request-handler task");
 
         Ok(Self {
+            _config: config,
+            _iface: iface,
             _log: log,
             message_id: AtomicU64::new(0),
             outgoing_request_tx,
@@ -232,8 +308,13 @@ impl Controller {
             message,
             data: None,
         };
-        let _reply = self.rpc(request).await.unwrap();
-        todo!();
+        let reply = self.rpc(request).await?;
+        Ok(reply
+            .data
+            .unwrap()
+            .into_iter()
+            .map(|x| Status::from_bits(x).unwrap())
+            .collect())
     }
 
     /// Read the memory map of a set of transceiver modules.
@@ -254,13 +335,23 @@ impl Controller {
             message,
             data: None,
         };
-        let reply = self.rpc(request).await.unwrap();
+        let reply = self.rpc(request).await?;
+
+        // If we get back a ReadFailed error, one possibility is that we asked
+        // to read a transceiver that's not present.
+        let data = match reply.message.body {
+            MessageBody::SpResponse(SpResponse::Error(MessageError::ReadFailed)) => {
+                return Err(Error::ReadFailed);
+            }
+            MessageBody::SpResponse(SpResponse::Error(e)) => return Err(Error::from(e)),
+            MessageBody::SpResponse(SpResponse::Read(_)) => reply.data.unwrap(),
+            _ => panic!("Unexpected message type"),
+        };
+
         // We expect data to be a flattened vec of vecs, with the data from each
         // referenced transceiver. Split it into chunks sized by the number of
         // bytes we expected to read.
-        let data = reply
-            .data
-            .unwrap()
+        let data = data
             .chunks_exact(usize::from(read.len()))
             .map(Vec::from)
             .collect::<Vec<_>>();
@@ -283,9 +374,6 @@ impl Controller {
     }
 }
 
-const RESEND_INTERVAL: Duration = Duration::from_secs(1);
-const MAX_PACKET_SIZE: usize = MAX_PAYLOAD_SIZE + Message::MAX_SIZE;
-
 // A POD type holding the data we need for the main I/O loop. See `IoLoop::run`
 // for details.
 #[derive(Debug)]
@@ -293,17 +381,21 @@ struct IoLoop {
     log: Logger,
     socket: UdpSocket,
     peer_addr: SocketAddrV6,
+    n_retries: usize,
+    resend: Interval,
     outstanding_request: Option<OutstandingHostRequest>,
     outgoing_request_rx: mpsc::Receiver<OutstandingHostRequest>,
     outgoing_response_rx: mpsc::Receiver<HostRpcResponse>,
     incoming_request_tx: mpsc::Sender<SpRpcRequest>,
-    resend: Interval,
 }
 
 impl IoLoop {
     fn new(
         log: Logger,
         socket: UdpSocket,
+        peer_addr: SocketAddrV6,
+        n_retries: Option<usize>,
+        retry_interval: Duration,
         outgoing_request_rx: mpsc::Receiver<OutstandingHostRequest>,
         outgoing_response_rx: mpsc::Receiver<HostRpcResponse>,
         incoming_request_tx: mpsc::Sender<SpRpcRequest>,
@@ -311,12 +403,13 @@ impl IoLoop {
         Self {
             log,
             socket,
-            peer_addr: SocketAddrV6::new(Ipv6Addr::from(ADDR), PORT, 0, 0),
+            peer_addr,
+            n_retries: n_retries.unwrap_or(usize::MAX),
+            resend: interval(retry_interval),
             outstanding_request: None,
             outgoing_request_rx,
             outgoing_response_rx,
             incoming_request_tx,
-            resend: interval(RESEND_INTERVAL),
         }
     }
 
@@ -440,6 +533,7 @@ impl IoLoop {
     async fn run(mut self) {
         let mut rx_buf = [0; MAX_PACKET_SIZE];
         let mut tx_buf = [0; MAX_PACKET_SIZE];
+        let mut n_retries = 0;
 
         loop {
             tokio::select! {
@@ -468,15 +562,27 @@ impl IoLoop {
                     );
                     self.send_outgoing_request(&mut tx_buf).await;
                     self.resend.reset();
+                    n_retries += 1;
                 }
 
                 // If we _do_ have an outstanding request, we need to resend it
                 // periodically until we get a response. Wait for up to the resend
                 // interval of inactivity, and then possibly retry.
                 _ = self.resend.tick(), if self.outstanding_request.is_some() => {
-                    debug!(self.log, "timed out without response, retrying");
-                    self.send_outgoing_request(&mut tx_buf).await;
-                    self.resend.reset();
+                    if n_retries < self.n_retries {
+                        debug!(self.log, "timed out without response, retrying");
+                        self.send_outgoing_request(&mut tx_buf).await;
+                        self.resend.reset();
+                        n_retries += 1;
+                    } else {
+                        error!(
+                            self.log,
+                            "failed to send message within {n_retries} retries"
+                        );
+                        let old = self.outstanding_request.take().unwrap();
+                        old.response_tx.send(Err(Error::MaxRetries(n_retries))).unwrap();
+                        n_retries = 0;
+                    }
                 }
 
                 // Poll for outgoing responses we need to send.
@@ -574,17 +680,50 @@ impl IoLoop {
                     //
                     // We never expect these message types to be sent to us.
                     if matches!(message.body, MessageBody::HostRequest(_) | MessageBody::HostResponse(_)) {
-                        debug!(self.log, "wrong message type"; "peer" => peer);
-                        let err = MessageError::ProtocolError;
-                        probes::bad__message!(|| (peer.ip(), format!("{:?}", err)));
-                        self.send_protocol_error(
-                            &peer,
-                            message.header,
-                            message.modules,
-                            err,
-                            &mut tx_buf,
-                        ).await;
-                        continue;
+                        // We need to check the message ID to decide how to
+                        // proceed.
+                        //
+                        // If we have an outstanding request, and this incoming
+                        // message matches that ID, we need to fail this
+                        // request. Otherwise we'll simply retry the message
+                        // again, which will obviously fail in the same way.
+                        //
+                        // Note that we can always take out of the Option. If it
+                        // is None, then we can replace it with None without
+                        // worry. If it is Some(_), we want to replace it
+                        // anyway when we fail this request.
+                        let maybe_outstanding = self.outstanding_request.take();
+                        if let Some(request) = maybe_outstanding {
+                            if request.request.message.header.message_id ==
+                                message.header.message_id {
+                                debug!(
+                                    self.log,
+                                    "received incorrect message type, \
+                                    but with message ID that matches our \
+                                    outstanding message ID, failing the \
+                                    request";
+                                    "message" => ?message,
+                                    "peer" => peer,
+                                );
+                                request.response_tx.send(
+                                    Err(Error::Protocol(MessageError::ProtocolError))
+                                ).unwrap();
+                            }
+                        } else {
+                            // We don't have an outstanding request, so we try
+                            // to inform the SP that this message wasn't
+                            // supposed to be sent to us.
+                            debug!(self.log, "wrong message type"; "peer" => peer);
+                            let err = MessageError::ProtocolError;
+                            probes::bad__message!(|| (peer.ip(), format!("{:?}", err)));
+                            self.send_protocol_error(
+                                &peer,
+                                message.header,
+                                message.modules,
+                                err,
+                                &mut tx_buf,
+                            ).await;
+                        }
                     }
 
                     // Check that we have data, if the message is supposed to

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -170,6 +170,11 @@ impl PortMask {
     pub const fn selected_transceiver_count(&self) -> usize {
         self.0.count_ones() as _
     }
+
+    /// Convience function to address all transceivers.
+    pub const fn all() -> Self {
+        Self(!0)
+    }
 }
 
 /// Identifier for a set of transceiver modules accessed through a single FPGA.
@@ -183,6 +188,15 @@ impl ModuleId {
     /// Return the number of transceivers addressed by `self`.
     pub const fn selected_transceiver_count(&self) -> usize {
         self.ports.selected_transceiver_count()
+    }
+
+    /// Convenience method to build a `ModuleId` that selects all transceivers
+    /// on the given FPGA.
+    pub const fn all_transceivers(&self, fpga_id: u8) -> Self {
+        Self {
+            fpga_id,
+            ports: PortMask::all(),
+        }
     }
 }
 
@@ -227,5 +241,15 @@ mod tests {
         assert!(mask.set(200).is_err());
         assert!(mask.clear(200).is_err());
         assert!(mask.is_set(200).is_err());
+    }
+
+    #[test]
+    fn test_port_mask_all() {
+        assert_eq!(PortMask::all().0, 0xFFFF);
+    }
+
+    #[test]
+    fn test_selected_transceiver_count() {
+        assert_eq!(PortMask(0b101).selected_transceiver_count(), 2);
     }
 }

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -45,11 +45,12 @@ impl Message {
     /// Return the length of the expected data that should follow `self`.
     pub fn expected_data_len(&self) -> usize {
         let bytes_per_xcvr = match self.body {
-            MessageBody::HostRequest(HostRequest::Write(inner)) => inner.len(),
-            MessageBody::SpResponse(SpResponse::Read(inner)) => inner.len(),
+            MessageBody::HostRequest(HostRequest::Write(inner)) => usize::from(inner.len()),
+            MessageBody::SpResponse(SpResponse::Read(inner)) => usize::from(inner.len()),
+            MessageBody::SpResponse(SpResponse::Status) => core::mem::size_of::<Status>(),
             _ => 0,
         };
-        self.modules.selected_transceiver_count() * usize::from(bytes_per_xcvr)
+        self.modules.selected_transceiver_count() * bytes_per_xcvr
     }
 }
 


### PR DESCRIPTION
- Adds a `Config` type for specifying the configuration for a `Controller`. Currently provides knobs for retry duration/interval, local/remote IP addresses, and the IP interface. Plumbs these up to the `xcvradm` CLI tool.
- Adds a few convenience constructors to `PortMask` and `ModuleId`.
- Fixes bug where we send back a ProtocolError if the SP responds incorrectly to our outstanding request, but then just continues to try to send it. That leads to a silly ping-pong of error messages back and forth. Now we fail the request if we ever get back a ProtocolError, since it could never succeed.