### PR TITLE
Add hardware error type and bump to V2

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -297,7 +297,7 @@ impl Controller {
     // Return a header using the next available message ID.
     fn next_header(&self) -> Header {
         Header {
-            version: message::version::V1,
+            version: message::version::V2,
             message_id: self.message_id.fetch_add(1, Ordering::SeqCst),
         }
     }
@@ -657,7 +657,7 @@ impl IoLoop {
                     probes::message__received!(|| (peer.ip(), &message));
 
                     // Sanity check the protocol version.
-                    if message.header.version != message::version::V1 {
+                    if message.header.version != message::version::V2 {
                         // If the version does not match, we're choosing to drop
                         // the packet rather than reply with a version mismatch
                         // error. Without a matching version, we can't really
@@ -666,7 +666,7 @@ impl IoLoop {
                         debug!(
                             self.log,
                             "deserialized message with incorrect version";
-                            "expected" => message::version::V1,
+                            "expected" => message::version::V2,
                             "actual" => message.header.version,
                             "peer" => peer,
                         );
@@ -675,7 +675,7 @@ impl IoLoop {
                                 peer.ip(),
                                 format!(
                                     "incorrect version: expected {}, actual {}",
-                                    message::version::V1,
+                                    message::version::V2,
                                     message.header.version,
                                 ),
                             )

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -345,7 +345,7 @@ impl Controller {
         // If we get back a ReadFailed error, one possibility is that we asked
         // to read a transceiver that's not present.
         let data = match reply.message.body {
-            MessageBody::SpResponse(SpResponse::Error(MessageError::ReadFailed)) => {
+            MessageBody::SpResponse(SpResponse::Error(MessageError::ReadFailed(..))) => {
                 return Err(Error::ReadFailed);
             }
             MessageBody::SpResponse(SpResponse::Error(e)) => return Err(Error::from(e)),

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -297,7 +297,7 @@ impl Controller {
     // Return a header using the next available message ID.
     fn next_header(&self) -> Header {
         Header {
-            version: message::version::V2,
+            version: message::version::CURRENT,
             message_id: self.message_id.fetch_add(1, Ordering::SeqCst),
         }
     }
@@ -657,7 +657,7 @@ impl IoLoop {
                     probes::message__received!(|| (peer.ip(), &message));
 
                     // Sanity check the protocol version.
-                    if message.header.version != message::version::V2 {
+                    if message.header.version != message::version::CURRENT {
                         // If the version does not match, we're choosing to drop
                         // the packet rather than reply with a version mismatch
                         // error. Without a matching version, we can't really
@@ -666,7 +666,7 @@ impl IoLoop {
                         debug!(
                             self.log,
                             "deserialized message with incorrect version";
-                            "expected" => message::version::V2,
+                            "expected" => message::version::CURRENT,
                             "actual" => message.header.version,
                             "peer" => peer,
                         );
@@ -675,7 +675,7 @@ impl IoLoop {
                                 peer.ip(),
                                 format!(
                                     "incorrect version: expected {}, actual {}",
-                                    message::version::V2,
+                                    message::version::CURRENT,
                                     message.header.version,
                                 ),
                             )

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -161,11 +161,11 @@ pub enum HwError {
     /// Reading back the read buffer failed
     ReadBufFailed,
 
-    /// The write setup operation failed
-    WriteSetupFailed,
+    /// Loading the write buffer failed
+    WriteBufFailed,
 
-    /// The write operation failed
-    WriteFailed,
+    /// The write setup call failed
+    WriteSetupFailed,
 }
 
 #[cfg(any(test, feature = "std"))]

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -62,10 +62,16 @@ pub enum Error {
     InvalidMemoryAccess { offset: u8, len: u8 },
 
     /// A read failed for some reason.
-    ReadFailed,
+    ReadFailed(HwError),
 
     /// A write failed for some reason.
-    WriteFailed,
+    WriteFailed(HwError),
+
+    /// A reset failed for some reason.
+    ResetFailed(HwError),
+
+    /// Reading transceiver status failed for some reason.
+    StatusFailed(HwError),
 
     /// A request would result in a response that is too large to fit in a
     /// single UDP message.
@@ -78,12 +84,77 @@ pub enum Error {
     /// packet.
     MissingData,
 
+    /// The trailing data is an unexpected size.
+    WrongDataSize,
+
     /// The version in the header is unexpected.
     VersionMismatch { expected: u8, actual: u8 },
 }
 
 #[cfg(any(test, feature = "std"))]
 impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize, SerializedSize)]
+#[cfg_attr(any(test, feature = "std"), derive(thiserror::Error))]
+pub enum HwError {
+    /// Could not set the reset pin
+    SetResetFailed,
+
+    /// Could not clear the reset pin
+    ClearResetFailed,
+
+    /// Failed to read the `EN` register
+    EnabledReadFailed,
+
+    /// Failed to read the `RESET` register
+    ResetReadFailed,
+
+    /// Failed to read the `LPMODE` register
+    LpReadFailed,
+
+    /// Failed to read the `PRESENT` register
+    PresentReadFailed,
+
+    /// Failed to read the `IRQ` register
+    IrqReadFailed,
+
+    /// Could not set up the write buffer for a page select
+    PageSelectWriteBufFailed,
+
+    /// The page select write operation failed
+    PageSelectWriteFailed,
+
+    /// Could not set up the write buffer for a bank select
+    BankSelectWriteBufFailed,
+
+    /// The bank select write operation failed
+    BankSelectWriteFailed,
+
+    /// Waiting for the operation to complete failed
+    WaitFailed,
+
+    /// The FPGA reported an I2C error
+    I2cError,
+
+    /// The read setup operation failed
+    ReadSetupFailed,
+
+    /// Reading back the read buffer failed
+    ReadBufFailed,
+
+    /// The write setup operation failed
+    WriteSetupFailed,
+
+    /// The write operation failed
+    WriteFailed,
+}
+
+#[cfg(any(test, feature = "std"))]
+impl std::fmt::Display for HwError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -37,7 +37,7 @@ pub const PORT: u16 = 11112;
 // NOTE: This isn't a `std::net::Ipv6Addr` to support `no_std` environments.
 pub const ADDR: [u16; 8] = [0xff02, 0, 0, 0, 0, 0, 0x1de, 2];
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, SerializedSize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, SerializedSize)]
 #[cfg_attr(any(test, feature = "std"), derive(thiserror::Error))]
 pub enum Error {
     /// An attempt to reference an invalid transceiver port on a Sidecar or FPGA.
@@ -73,6 +73,9 @@ pub enum Error {
     /// Reading transceiver status failed for some reason.
     StatusFailed(HwError),
 
+    /// Failed to set power mode
+    PowerModeFailed(HwError),
+
     /// A request would result in a response that is too large to fit in a
     /// single UDP message.
     RequestTooLarge,
@@ -107,8 +110,20 @@ pub enum HwError {
     /// Could not clear the reset pin
     ClearResetFailed,
 
+    /// Failed to clear the power enable mask
+    ClearPowerEnableFailed,
+
+    /// Failed to set the power enable mask
+    SetPowerEnableFailed,
+
+    /// Failed to clear the low power mode mask
+    ClearLpModeFailed,
+
+    /// Failed to set the low power mode mask
+    SetLpModeFailed,
+
     /// Failed to read the `EN` register
-    EnabledReadFailed,
+    EnableReadFailed,
 
     /// Failed to read the `RESET` register
     ResetReadFailed,
@@ -170,7 +185,7 @@ type MaskType = u16;
 /// applies.
 ///
 /// Note that this bitmask is always per-FPGA.
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize, SerializedSize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, SerializedSize)]
 pub struct PortMask(pub MaskType);
 
 impl PortMask {

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -18,6 +18,8 @@ use serde::Serialize;
 pub mod version {
     pub const V1: u8 = 1;
     pub const V2: u8 = 2;
+
+    pub const CURRENT: u8 = V2;
 }
 
 /// A common header to all messages between host and SP.

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 
 pub mod version {
     pub const V1: u8 = 1;
+    pub const V2: u8 = 2;
 }
 
 /// A common header to all messages between host and SP.


### PR DESCRIPTION
This adds a fine-grained `HwError` which provides details on SP -> FPGA -> transceiver errors.

It also introduces a few new member to the top-level `Error` enum.