### PR TITLE
Add a reset method

### DIFF
--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -90,6 +90,9 @@ enum Cmd {
     /// enable, and power mode.
     Status,
 
+    /// Reset the addressed modules.
+    Reset,
+
     /// Set the power module of the addressed modules.
     SetPower {
         /// The desired power mode.
@@ -144,6 +147,7 @@ async fn main() {
             let (modules, status) = controller.status(requested_modules).await.unwrap();
             print_module_status(modules, status);
         }
+        Cmd::Reset => controller.reset(requested_modules).await.unwrap(),
         Cmd::ReadLower { offset, len } => {
             let read = MemoryRead::new(sff8636::Page::Lower, offset, len).unwrap();
             let (modules, data) = controller.read(requested_modules, read).await.unwrap();

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -404,6 +404,20 @@ impl Controller {
         Ok((modules, identity.into_iter().map(|(_k, v)| v).collect()))
     }
 
+    /// Reset a set of transceiver modules.
+    pub async fn reset(&self, modules: ModuleId) -> Result<(), Error> {
+        let message = Message {
+            header: self.next_header(),
+            modules,
+            body: MessageBody::HostRequest(HostRequest::Reset),
+        };
+        let request = HostRpcRequest {
+            message,
+            data: None,
+        };
+        self.rpc(request).await.map(|_| ())
+    }
+
     /// Set the power mode for a set of transceiver modules.
     pub async fn set_power_mode(
         &self,


### PR DESCRIPTION
- Adds the `Controller::reset` method for reseting some transceivers.
- Adds a `xcvradm reset` subcommand for consuming it.