### PR TITLE
Handle requests via a channel

### DIFF
--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -6,7 +6,6 @@ default-run = "xcvradm"
 
 [dependencies]
 anyhow = "1"
-async-trait = "0.1"
 hubpack = "0.1.0"
 serde = "1"
 slog-async = "2"


### PR DESCRIPTION
Removes the async-trait for a request handler, and instead opts to take a send-half of a channel at construction. Rather than calling the request handler method directly, the controller now sends the request on that channel along with a oneshot for the reponse. It awaits the response on that oneshot; if it's Some(_), the message is serialized and sent back to the peer over the UDP socket; if it's None, the message is dropped. This approach reduces the complexity around ownership and generally allows more freedom to run the controller and handler in separate tasks.