### PR TITLE
Don't take an outstanding message unless we get its response

### DIFF
--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -494,7 +494,7 @@ async fn main() -> anyhow::Result<()> {
                     }
                     .context("Invalid CMIS upper page")?;
                     MemoryWrite::new(cmis::Page::Upper(page), offset, len)
-                        .context("Failed to setup upper page memory read")?
+                        .context("Failed to setup upper page memory write")?
                 }
                 (_, _) => unreachable!("clap didn't do its job"),
             };


### PR DESCRIPTION
The `IOLoop` previously took out of the optional outstanding message whenever we got a well-formed response, and _then_ checked if the message ID confirms that it's for the outstanding response. That was premature; we should only remove the outstanding message _after_ verifying the response we have is actually for that message.