### PR TITLE
More flexible methods for addressing transceivers

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1207,8 +1207,7 @@ impl IoLoop {
 
                     // Check that we have data, if the message is supposed to
                     // contain it.
-                    let expected_len = message.expected_data_len();
-                    let data = if expected_len > 0  {
+                    let data = if let Some(expected_len) = message.expected_data_len() {
                         if remainder.len() < expected_len {
                             error!(
                                 self.log,

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -47,14 +47,20 @@ pub struct Message {
 
 impl Message {
     /// Return the length of the expected data that should follow `self`.
-    pub fn expected_data_len(&self) -> usize {
+    ///
+    /// If the message expects no data at all, `None` is returned. If the
+    /// message generally expects data, but the particular contents of this one
+    /// imply the data should be empty (e.g., zero transceivers were addressed),
+    /// then `Some(0)` is returned. Otherwise, `Some(x)` is returned for a
+    /// nonzero `x`.
+    pub fn expected_data_len(&self) -> Option<usize> {
         let bytes_per_xcvr = match self.body {
             MessageBody::HostRequest(HostRequest::Write(inner)) => usize::from(inner.len()),
             MessageBody::SpResponse(SpResponse::Read(inner)) => usize::from(inner.len()),
             MessageBody::SpResponse(SpResponse::Status) => core::mem::size_of::<Status>(),
-            _ => 0,
+            _ => return None,
         };
-        self.modules.selected_transceiver_count() * bytes_per_xcvr
+        Some(self.modules.selected_transceiver_count() * bytes_per_xcvr)
     }
 }
 


### PR DESCRIPTION
Improves parsing of the list of transceivers on the command line, to allow a list of indices; all transceivers in a specific power mode (e.g., "off"); or all of a specific management interface (e.g., "cmis").