### PR TITLE
Add message for collecting MAC addresses from SP

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test (helios)"
 #: variety = "basic"
 #: target = "helios-latest"
-#: rust_toolchain = "1.66"
+#: rust_toolchain = "stable"
 #: output_rules = []
 #:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ name = "transceiver-messages"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "clap",
  "hubpack",
  "serde",
  "thiserror",

--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -885,14 +885,14 @@ fn print_module_memory_model(modules: ModuleId, models: Vec<MemoryModel>) {
 fn print_mac_address_range(macs: MacAddrs, summary: bool) {
     if summary {
         let base: String = macs
-            .base_mac
+            .base_mac()
             .iter()
             .map(|octet| format!("{octet:02x}"))
             .collect::<Vec<_>>()
             .join(":");
         println!("Base:   {base}");
-        println!("Count:  {}", macs.count);
-        println!("Stride: {}", macs.stride);
+        println!("Count:  {}", macs.count());
+        println!("Stride: {}", macs.stride());
     } else {
         for mac in macs.iter() {
             let mac_s: String = mac

--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -34,6 +34,7 @@ use transceiver_messages::mgmt::sff8636;
 use transceiver_messages::mgmt::ManagementInterface;
 use transceiver_messages::mgmt::MemoryRead;
 use transceiver_messages::mgmt::MemoryWrite;
+use transceiver_messages::MacAddrs;
 use transceiver_messages::ModuleId;
 use transceiver_messages::PortMask;
 
@@ -385,6 +386,14 @@ enum Cmd {
     /// indicates that page `0x10` is supported, and the module implements banks
     /// 0 and 1 (16 lanes).
     MemoryModel,
+
+    /// Return the MAC addresses for the particular system allotted by its
+    /// FRUID.
+    Macs {
+        /// Print a summary of the MAC range, rather than each address.
+        #[arg(short, long, default_value_t = false)]
+        summary: bool,
+    },
 }
 
 fn load_write_data(file: Option<PathBuf>, kind: InputKind) -> anyhow::Result<Vec<u8>> {
@@ -691,6 +700,13 @@ async fn main() -> anyhow::Result<()> {
                 .context("Failed to get memory model")?;
             print_module_memory_model(modules, layout);
         }
+        Cmd::Macs { summary } => {
+            let macs = controller
+                .mac_addrs()
+                .await
+                .context("Failed to get MAC addresses")?;
+            print_mac_address_range(macs, summary);
+        }
     }
     Ok(())
 }
@@ -863,6 +879,29 @@ fn print_module_memory_model(modules: ModuleId, models: Vec<MemoryModel>) {
     let fpga_id = modules.fpga_id;
     for (port, model) in modules.ports.to_indices().zip(models.into_iter()) {
         println!("{fpga_id:>WIDTH$} {port:>WIDTH$} {model}");
+    }
+}
+
+fn print_mac_address_range(macs: MacAddrs, summary: bool) {
+    if summary {
+        let base: String = macs
+            .base_mac
+            .iter()
+            .map(|octet| format!("{octet:02x}"))
+            .collect::<Vec<_>>()
+            .join(":");
+        println!("Base:   {base}");
+        println!("Count:  {}", macs.count);
+        println!("Stride: {}", macs.stride);
+    } else {
+        for mac in macs.iter() {
+            let mac_s: String = mac
+                .iter()
+                .map(|octet| format!("{octet:02x}"))
+                .collect::<Vec<_>>()
+                .join(":");
+            println!("{mac_s}");
+        }
     }
 }
 

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 bitflags = "1"
 hubpack = "0.1.0"
 
+[dependencies.clap]
+version = "4"
+optional = true
+
 [dependencies.serde]
 version = "1"
 features = [ "derive" ]
@@ -17,7 +21,7 @@ version = "1"
 optional = true
 
 [features]
-std = [ "dep:thiserror" ]
+std = [ "dep:thiserror", "dep:clap" ]
 default = [ "std" ]
 
 [dev-dependencies]

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -10,6 +10,7 @@ use super::mgmt::ManagementInterface;
 use super::mgmt::MemoryRead;
 use super::mgmt::MemoryWrite;
 use super::Error;
+use super::MacAddrs;
 use super::ModuleId;
 use hubpack::SerializedSize;
 use serde::Deserialize;
@@ -21,8 +22,9 @@ pub mod version {
     pub const V3: u8 = 3;
     pub const V4: u8 = 4;
     pub const V5: u8 = 5;
+    pub const V6: u8 = 6;
 
-    pub const CURRENT: u8 = V5;
+    pub const CURRENT: u8 = V6;
 }
 
 /// A common header to all messages between host and SP.
@@ -131,6 +133,9 @@ pub enum HostRequest {
     /// transceivers' memory maps such as the temperature or power draw, for the
     /// purposes of health and safety monitoring.
     ManagementInterface(ManagementInterface),
+
+    /// Ask the SP to return the available MAC addresses for host system use.
+    MacAddrs,
 }
 
 /// A response to a host request, sent from SP to host.
@@ -164,6 +169,9 @@ pub enum SpResponse {
     /// A generic acknowledgement of a specific message, where no further data
     /// is required from the SP.
     Ack,
+
+    /// The requested MAC address information for the host.
+    MacAddrs(MacAddrs),
 }
 
 /// A request from the SP to the host.


### PR DESCRIPTION
- Add the `MacAddrs` message to the protocol, and `MacAddrs` type for representing the MAC range for various kinds of systems.
- Adds method to `Controller` and `xcvradm` subcommand for exercising.