### PR TITLE
Add a logical failure mask to HwError::I2cError

### DIFF
--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -267,24 +267,24 @@ pub enum HwError {
     )]
     WaitFailed,
 
-    /// The FPGA reported an I2C error
+    /// The FPGA reported an I2C error.  u32 is a logical mask for which
+    /// ports saw a failure.
     #[cfg_attr(
         any(test, feature = "std"),
-        error("FPGA reported an I2C error, module may not be present")
+        error("FPGA reported an I2C error, module may not be present. u32 is a logical mask for which ports saw a failure.")
     )]
-    I2cError,
+    I2cError(u32),
 
     /// The read setup operation failed
     #[cfg_attr(any(test, feature = "std"), error("Read setup operation failed"))]
     ReadSetupFailed,
 
-    /// Reading back the read buffer failed. u32 is a logical mask for which
-    /// ports saw a failure.
+    /// Reading back the read buffer failed
     #[cfg_attr(
         any(test, feature = "std"),
-        error("Reading back the FPGA read buffer failed. u32 is a logical mask for which ports saw a failure.")
+        error("Reading back the FPGA read buffer failed")
     )]
-    ReadBufFailed(u32),
+    ReadBufFailed,
 
     /// Loading the write buffer failed
     #[cfg_attr(

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -271,7 +271,7 @@ pub enum HwError {
     /// ports saw a failure.
     #[cfg_attr(
         any(test, feature = "std"),
-        error("FPGA reported an I2C error, module may not be present. Logical mask for which ports saw a failure: 0x{:08x}")
+        error("FPGA reported an I2C error, module may not be present. Logical mask for which ports saw a failure: 0x{0:08x}")
     )]
     I2cError(u32),
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -271,7 +271,7 @@ pub enum HwError {
     /// ports saw a failure.
     #[cfg_attr(
         any(test, feature = "std"),
-        error("FPGA reported an I2C error at the following indices: {:?}", .0.to_indices().collect::<Vec<_>>())
+        error("FPGA reported an I2C error on the following ports: {:?}", .0.to_indices().collect::<Vec<_>>())
     )]
     I2cError(PortMask),
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -278,12 +278,13 @@ pub enum HwError {
     #[cfg_attr(any(test, feature = "std"), error("Read setup operation failed"))]
     ReadSetupFailed,
 
-    /// Reading back the read buffer failed
+    /// Reading back the read buffer failed. u32 is a logical mask for which
+    /// ports saw a failure.
     #[cfg_attr(
         any(test, feature = "std"),
-        error("Reading back the FPGA read buffer failed")
+        error("Reading back the FPGA read buffer failed. u32 is a logical mask for which ports saw a failure.")
     )]
-    ReadBufFailed,
+    ReadBufFailed(u32),
 
     /// Loading the write buffer failed
     #[cfg_attr(

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -271,9 +271,9 @@ pub enum HwError {
     /// ports saw a failure.
     #[cfg_attr(
         any(test, feature = "std"),
-        error("FPGA reported an I2C error, module may not be present. Logical mask for which ports saw a failure: 0x{0:08x}")
+        error("FPGA reported an I2C error at the following indices: {:?}", .0.to_indices().collect::<Vec<_>>())
     )]
-    I2cError(u32),
+    I2cError(PortMask),
 
     /// The read setup operation failed
     #[cfg_attr(any(test, feature = "std"), error("Read setup operation failed"))]

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -271,7 +271,7 @@ pub enum HwError {
     /// ports saw a failure.
     #[cfg_attr(
         any(test, feature = "std"),
-        error("FPGA reported an I2C error, module may not be present. u32 is a logical mask for which ports saw a failure.")
+        error("FPGA reported an I2C error, module may not be present. Logical mask for which ports saw a failure: {0:x}")
     )]
     I2cError(u32),
 

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -271,7 +271,7 @@ pub enum HwError {
     /// ports saw a failure.
     #[cfg_attr(
         any(test, feature = "std"),
-        error("FPGA reported an I2C error, module may not be present. Logical mask for which ports saw a failure: {0:x}")
+        error("FPGA reported an I2C error, module may not be present. Logical mask for which ports saw a failure: 0x{:08x}")
     )]
     I2cError(u32),
 

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -20,8 +20,9 @@ pub mod version {
     pub const V2: u8 = 2;
     pub const V3: u8 = 3;
     pub const V4: u8 = 4;
+    pub const V5: u8 = 5;
 
-    pub const CURRENT: u8 = V4;
+    pub const CURRENT: u8 = V5;
 }
 
 /// A common header to all messages between host and SP.


### PR DESCRIPTION
This is part of the efforts to address https://github.com/oxidecomputer/hubris/issues/1069