### PR TITLE
Add committed minimum protocol version

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1640,9 +1640,11 @@ impl IoLoop {
                     // because the _peer_ may not be able to handle the message.
                     //
                     // If the version is _newer_ than `CURRENT`, we can still
-                    // process it. That's because all of our messages can be
-                    // decoded and processed by the peer, who has also committed
-                    // to this compatibility.
+                    // process it, because we successfully deserialized it
+                    // above. Our peer has committed to the same backwards
+                    // compatibility guarantees, so successful deserialization
+                    // means that we share a common understanding of the message
+                    // semantics with our peer.
                     if message.header.version < message::version::MIN {
                         debug!(
                             self.log,

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -31,7 +31,7 @@ pub const PORT: u16 = 11112;
 
 /// The IPv6 multicast address on which both peers should listen.
 ///
-/// See RFD 250 for backgroun on this specific address. Briefly, this is a
+/// See RFD 250 for background on this specific address. Briefly, this is a
 /// link-local multicast address that is unlikely to conflict with others, such
 /// as the All-Nodes address.
 //


### PR DESCRIPTION
- Adds a minimum version of the network protocol. This is _committed_, in that we can never break backwards compatibility. There is also a CURRENT version, which can be different. This only serves as informational, to detect version mismatches and possibly warn about them.
- Adds tests that we can correctly [de]serialize _all_ current data used in the protocol. This should catch any changes that break the existing wire-encoding.
- Adds a sanity check for the new behavior in the IO loop for handling responses from the SP that do not match our version. We currently only _fail_ responses below our minimum committed version. We should never get responses to these, since all existing SP code will drop messages that don't match its own version, but this is a helpful sanity check. We also add basic tests that we still correctly receive, decode, and handle responses from the SP where the version is below our own, but above the minimum, and also above our own. Assuming that the SP is also updated to respect this protocol, we should not have any further protocol mismatch errors _that we cannot detect on the host_. Specifically, the SP should be updated to try to handle host requests, even when those don't match its own version. If it can successfully decode the message, it should send a response (success or error). If it _cannot_ decode the message, it should send a protocol error or other error indicating that. Those error messages _are_ among the currently-supported set, and so should always be receivable by the host.