### PR TITLE
Fix out-of-order parsing of module data

### DIFF
--- a/controller/src/ioloop.rs
+++ b/controller/src/ioloop.rs
@@ -795,7 +795,7 @@ impl IoLoop {
                     // from the peer.
                     let msg_buf = &rx_buf[..n_bytes];
 
-                    let (header, remainder) = match hubpack::deserialize::<Header>(&msg_buf) {
+                    let (header, remainder) = match hubpack::deserialize::<Header>(msg_buf) {
                         Err(e) => {
                             // Failed to deserialize the header. This is most
                             // unexpected.


### PR DESCRIPTION
- Reads for some kinds of complex data are split by ID. That issues SFF reads first, before CMIS, simply because that's the sort order of the `Identifier` enum. After reading, data was pushed onto a vector, which may not respect the actual module order. For example, a CMIS module appearing before an SFF would result in seeing the SFF data as applying to the CMIS. Fixed by using a map from module index to the read data, which is collected into a vector at the end.
- Apply a few clippy nits