### PR TITLE
Add Header types to USDT probes

### DIFF
--- a/controller/src/ioloop.rs
+++ b/controller/src/ioloop.rs
@@ -127,7 +127,7 @@ impl IoLoop {
                 });
                 probes::message__sent!(|| {
                     let peer = IpAddr::V6(*self.peer_addr.ip());
-                    (peer, &response.message)
+                    (peer, &response.header, &response.message)
                 });
             }
         }
@@ -209,7 +209,7 @@ impl IoLoop {
                 });
                 probes::message__sent!(|| {
                     let peer = IpAddr::V6(*self.peer_addr.ip());
-                    (peer, &request.request.message)
+                    (peer, &request.request.header, &request.request.message)
                 });
                 self.resend.reset();
             }
@@ -256,7 +256,7 @@ impl IoLoop {
                 });
                 probes::message__sent!(|| {
                     let peer = IpAddr::V6(*self.peer_addr.ip());
-                    (peer, &message)
+                    (peer, &header, &message)
                 });
                 assert_eq!(n_bytes, serialized_len);
             }
@@ -273,7 +273,7 @@ impl IoLoop {
     ) {
         match hubpack::deserialize(rx_buf) {
             Ok((message, _remainder)) => {
-                probes::message__received!(|| (peer.ip(), &message));
+                probes::message__received!(|| (peer.ip(), &header, &message));
                 debug!(
                     self.log,
                     "SP request message received";
@@ -346,7 +346,7 @@ impl IoLoop {
                     return;
                 };
 
-                probes::message__received!(|| (peer.ip(), &message));
+                probes::message__received!(|| (peer.ip(), &header, &message));
                 debug!(
                     self.log,
                     "SP error message received";
@@ -452,7 +452,7 @@ impl IoLoop {
         // error on the outstanding request's response channel.
         let (message, remainder) = match hubpack::deserialize::<Message>(rx_buf) {
             Ok((message, remainder)) => {
-                probes::message__received!(|| (peer.ip(), &message));
+                probes::message__received!(|| (peer.ip(), &header, &message));
                 debug!(
                     self.log,
                     "SP response message received";

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -75,6 +75,7 @@ pub use transceiver_decode::Error as DecodeError;
 pub use transceiver_decode::Identifier;
 pub use transceiver_messages::mac::BadMacAddrRange;
 pub use transceiver_messages::mac::MacAddrs;
+use transceiver_messages::message::Header;
 pub use transceiver_messages::message::HwError;
 use transceiver_messages::message::Message;
 use transceiver_messages::message::MessageBody;
@@ -89,8 +90,8 @@ pub use transceiver_messages::ModuleId;
 mod probes {
     fn packet__received(peer: IpAddr, n_bytes: u64, data: *const u8) {}
     fn packet__sent(peer: IpAddr, n_bytes: u64, data: *const u8) {}
-    fn message__received(peer: IpAddr, message: &Message) {}
-    fn message__sent(peer: IpAddr, message: &Message) {}
+    fn message__received(peer: IpAddr, header: &Header, message: &Message) {}
+    fn message__sent(peer: IpAddr, header: &Header, message: &Message) {}
     fn bad__message(peer: IpAddr, reason: &str) {}
 }
 


### PR DESCRIPTION
Fixes #83.

With this, we now see:

```
BRM42220066 # dtrace -Zqn 'xcvr-ctl$target:::message-* { printf("%s\n", copyinstr(arg1)); }' -c '/tmp/xcvradm -i sidecar0 status'
Port Status
   0 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
   1 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
   2 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
   3 ENABLED | LOW_POWER_MODE | INTERRUPT
   4 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
   5 PRESENT | ENABLED | LOW_POWER_MODE | INTERRUPT | POWER_GOOD
   6 PRESENT | ENABLED | LOW_POWER_MODE | INTERRUPT | POWER_GOOD
   7 ENABLED | LOW_POWER_MODE | INTERRUPT
   8 ENABLED | LOW_POWER_MODE | INTERRUPT
   9 ENABLED | LOW_POWER_MODE | INTERRUPT
  10 ENABLED | LOW_POWER_MODE | INTERRUPT
  11 ENABLED | LOW_POWER_MODE | INTERRUPT
  12 ENABLED | LOW_POWER_MODE | INTERRUPT
  13 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
  14 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
  15 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
  16 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
  17 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
  18 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
  19 ENABLED | LOW_POWER_MODE | INTERRUPT
  20 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
  21 PRESENT | ENABLED | LOW_POWER_MODE | INTERRUPT | POWER_GOOD
  22 PRESENT | ENABLED | LOW_POWER_MODE | INTERRUPT | POWER_GOOD
  23 ENABLED | LOW_POWER_MODE | INTERRUPT
  24 ENABLED | LOW_POWER_MODE | INTERRUPT
  25 ENABLED | LOW_POWER_MODE | INTERRUPT
  26 ENABLED | LOW_POWER_MODE | INTERRUPT
  27 ENABLED | LOW_POWER_MODE | INTERRUPT
  28 ENABLED | LOW_POWER_MODE | INTERRUPT
  29 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
  30 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
  31 PRESENT | ENABLED | LOW_POWER_MODE | POWER_GOOD
{"ok":{"version":1,"message_id":0,"message_kind":"HostRequest"}}
{"ok":{"version":1,"message_id":0,"message_kind":"SpResponse"}}
```

which should allow us to correlate messages by their IDs.