### PR TITLE
Add support for ports disabled by Hubris

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "transceiver-controller"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "transceiver-messages"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitflags 2.2.1",
  "clap",

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transceiver-controller"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 default-run = "xcvradm"
 

--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -1082,17 +1082,17 @@ fn print_module_status(status_result: &ExtendedStatusResult, kind: StatusKind) {
 // useful to see how we print the table header itself.
 #[rustfmt::skip]
 fn print_all_status_header() {
-    println!(" +------------------------------------ Port");
-    println!(" |   +-------------------------------- {}", ExtendedStatus::PRESENT);
-    println!(" |   |   +---------------------------- {}", ExtendedStatus::ENABLED);
-    println!(" |   |   |   +------------------------ {}", ExtendedStatus::RESET);
-    println!(" |   |   |   |   +-------------------- {}", ExtendedStatus::LOW_POWER_MODE);
-    println!(" |   |   |   |   |   +---------------- {}", ExtendedStatus::INTERRUPT);
-    println!(" |   |   |   |   |   |   +------------ {}", ExtendedStatus::POWER_GOOD);
-    println!(" |   |   |   |   |   |   |   +-------- {}", ExtendedStatus::FAULT_POWER_TIMEOUT);
-    println!(" |   |   |   |   |   |   |   |   +---- {}", ExtendedStatus::FAULT_POWER_LOST);
-    println!(" |   |   |   |   |   |   |   |   |  +- {}", ExtendedStatus::DISABLED_BY_SP);
-    println!(" v   v   v   v   v   v   v   v   v  v");
+    println!(" +------------------------------------- Port");
+    println!(" |   +--------------------------------- {}", ExtendedStatus::PRESENT);
+    println!(" |   |   +----------------------------- {}", ExtendedStatus::ENABLED);
+    println!(" |   |   |   +------------------------- {}", ExtendedStatus::RESET);
+    println!(" |   |   |   |   +--------------------- {}", ExtendedStatus::LOW_POWER_MODE);
+    println!(" |   |   |   |   |   +----------------- {}", ExtendedStatus::INTERRUPT);
+    println!(" |   |   |   |   |   |   +------------- {}", ExtendedStatus::POWER_GOOD);
+    println!(" |   |   |   |   |   |   |   +--------- {}", ExtendedStatus::FAULT_POWER_TIMEOUT);
+    println!(" |   |   |   |   |   |   |   |   +----- {}", ExtendedStatus::FAULT_POWER_LOST);
+    println!(" |   |   |   |   |   |   |   |   |   +- {}", ExtendedStatus::DISABLED_BY_SP);
+    println!(" v   v   v   v   v   v   v   v   v   v");
 }
 
 fn print_all_status(status_result: &ExtendedStatusResult) {

--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -474,6 +474,13 @@ enum Cmd {
     /// power supply to be enabled again.
     ClearPowerFault,
 
+    /// Clears the "disabled" latch on a set of modules
+    ///
+    /// The SP may make a policy decision to disable modules (e.g. if they
+    /// aren't reporting temperatures to the thermal loop).  Clearing the latch
+    /// allows them to be powered on again.
+    ClearDisableLatch,
+
     /// Return the state of the addressed modules' attention LEDs.
     Leds,
 
@@ -885,6 +892,15 @@ async fn main() -> anyhow::Result<()> {
                 .clear_power_fault(modules)
                 .await
                 .context("Failed to clear power fault for modules")?;
+            if !args.ignore_errors {
+                print_failures(&ack_result.failures);
+            }
+        }
+        Cmd::ClearDisableLatch => {
+            let ack_result = controller
+                .clear_disable_latch(modules)
+                .await
+                .context("Failed to clear disable latch for modules")?;
             if !args.ignore_errors {
                 print_failures(&ack_result.failures);
             }

--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -43,6 +43,7 @@ use transceiver_messages::filter_module_data;
 use transceiver_messages::mac::MacAddrs;
 use transceiver_messages::message::ExtendedStatus;
 use transceiver_messages::message::LedState;
+use transceiver_messages::message::Status;
 use transceiver_messages::mgmt::cmis;
 use transceiver_messages::mgmt::sff8636;
 use transceiver_messages::mgmt::ManagementInterface;
@@ -967,13 +968,13 @@ async fn address_transceivers(
             // Fetch all status bits, and find those which match.
             let modules = ModuleId::all();
             let status_result = controller
-                .extended_status(modules)
+                .status(modules)
                 .await
                 .context("Failed to retrieve module status")?;
             filter_module_data(
                 status_result.modules,
                 status_result.status().iter(),
-                |_, st| st.contains(ExtendedStatus::PRESENT),
+                |_, st| st.contains(Status::PRESENT),
             )
             .0
         }

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -53,7 +53,7 @@ use transceiver_messages::message::MessageBody;
 use transceiver_messages::message::MessageKind;
 pub use transceiver_messages::message::ProtocolError;
 use transceiver_messages::message::SpResponse;
-pub use transceiver_messages::message::Status;
+pub use transceiver_messages::message::StatusV2;
 pub use transceiver_messages::mgmt;
 use transceiver_messages::mgmt::sff8636;
 use transceiver_messages::mgmt::ManagementInterface;
@@ -360,7 +360,7 @@ impl Controller {
         let (powered_modules, powered_status) = filter_module_data(
             status_result.modules,
             status_result.status().iter(),
-            |_, st| st.contains(Status::POWER_GOOD | Status::ENABLED),
+            |_, st| st.contains(StatusV2::POWER_GOOD | StatusV2::ENABLED),
         );
         let unpowered_modules = status_result.modules.remove(&powered_modules);
 
@@ -368,7 +368,7 @@ impl Controller {
         // Off.
         let (in_reset, _) =
             filter_module_data(powered_modules, powered_status.iter(), |_, status| {
-                status.contains(Status::RESET)
+                status.contains(StatusV2::RESET)
             });
 
         // At this point, we have the set of `unpowered_modules` and `in_reset`.
@@ -425,7 +425,7 @@ impl Controller {
                             // Hardware is in charge, so report the state of the
                             // `LPMode` pin itself.
                             PowerControl::UseLpModePin => {
-                                let state = if status.contains(Status::LOW_POWER_MODE) {
+                                let state = if status.contains(StatusV2::LOW_POWER_MODE) {
                                     PowerState::Low
                                 } else {
                                     PowerState::High
@@ -556,15 +556,17 @@ impl Controller {
                 // module, only which hardware signals it responds to.
                 let (need_power_enabled, _) =
                     filter_module_data(modules, status.iter(), |_, st| {
-                        !st.contains(Status::POWER_GOOD | Status::ENABLED)
-                            || st.contains(Status::RESET)
+                        !st.contains(StatusV2::POWER_GOOD | StatusV2::ENABLED)
+                            || st.contains(StatusV2::RESET)
                     });
 
                 // Check for any modules which need power applied, but which do
                 // _not_ already have reset asserted. We're going to assert
                 // reset on them now, but emit a warning.
                 let (need_reset_deasserted, _) =
-                    filter_module_data(modules, status.iter(), |_, st| st.contains(Status::RESET));
+                    filter_module_data(modules, status.iter(), |_, st| {
+                        st.contains(StatusV2::RESET)
+                    });
                 let need_power_but_not_reset = need_power_enabled.remove(&need_reset_deasserted);
                 let modules = if need_power_but_not_reset.selected_transceiver_count() > 0 {
                     warn!(
@@ -918,7 +920,7 @@ impl Controller {
 
     /// Report the status of a set of transceiver modules.
     pub async fn status(&self, modules: ModuleId) -> Result<StatusResult, Error> {
-        let message = Message::from(HostRequest::Status(modules));
+        let message = Message::from(HostRequest::StatusV2(modules));
         let request = HostRpcRequest {
             header: self.next_header(MessageKind::HostRequest),
             message,
@@ -927,7 +929,7 @@ impl Controller {
         let response = self.rpc(request).await?;
         match response.message.body {
             MessageBody::SpResponse(
-                st @ SpResponse::Status {
+                st @ SpResponse::StatusV2 {
                     modules,
                     failed_modules,
                 },
@@ -935,9 +937,8 @@ impl Controller {
                 let data = response.data.expect("Existence of data checked earlier");
                 let (data, error_data) = data.split_at(st.expected_data_len().unwrap());
                 let status = data
-                    .iter()
-                    .copied()
-                    .map(|x| Status::from_bits(x).unwrap())
+                    .chunks_exact(4)
+                    .map(|x| hubpack::deserialize(x).unwrap().0)
                     .collect();
                 let failures = Self::deserialize_hw_errors(failed_modules, error_data)?;
                 Ok(StatusResult {

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -863,6 +863,14 @@ impl Controller {
             .await
     }
 
+    /// Clears the `disabled` flag for a set of transceiver modules
+    ///
+    /// This allows them to be powered on again
+    pub async fn clear_disable_latch(&self, modules: ModuleId) -> Result<AckResult, Error> {
+        self.no_payload_request(HostRequest::ClearDisableLatch(modules))
+            .await
+    }
+
     /// Assert physical lpmode pin for a set of transceiver modules. Note: The
     /// effect this pin has on operation can change depending on if the software
     /// override of power control is set.

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -967,11 +967,13 @@ impl Controller {
                 },
             ) => {
                 let data = response.data.expect("Existence of data checked earlier");
-                let (data, error_data) = data.split_at(st.expected_data_len().unwrap());
-                let status = data
-                    .chunks_exact(4)
-                    .map(|x| hubpack::deserialize(x).unwrap().0)
-                    .collect();
+                let (mut data, error_data) = data.split_at(st.expected_data_len().unwrap());
+                let mut status = vec![];
+                for _ in 0..modules.selected_transceiver_count() {
+                    let (d, rest) = hubpack::deserialize(data).expect("data size checked earlier");
+                    status.push(d);
+                    data = rest;
+                }
                 let failures = Self::deserialize_hw_errors(failed_modules, error_data)?;
                 Ok(ExtendedStatusResult {
                     modules,

--- a/controller/src/results.rs
+++ b/controller/src/results.rs
@@ -31,8 +31,9 @@ use transceiver_decode::Monitors;
 use transceiver_decode::PowerControl;
 use transceiver_decode::VendorInfo;
 use transceiver_messages::merge_module_data;
+use transceiver_messages::message::ExtendedStatus;
 use transceiver_messages::message::LedState;
-use transceiver_messages::message::StatusV2;
+use transceiver_messages::message::Status;
 use transceiver_messages::remove_module_data;
 use transceiver_messages::ModuleId;
 
@@ -102,11 +103,21 @@ impl ReadResult {
 }
 
 /// The result of accessing the status of a set of transceivers.
-pub type StatusResult = ModuleResult<StatusV2>;
+pub type StatusResult = ModuleResult<Status>;
 
 impl StatusResult {
     /// Return the status read from the modules.
-    pub fn status(&self) -> &[StatusV2] {
+    pub fn status(&self) -> &[Status] {
+        &self.data
+    }
+}
+
+/// The result of accessing the extended status of a set of transceivers.
+pub type ExtendedStatusResult = ModuleResult<ExtendedStatus>;
+
+impl ExtendedStatusResult {
+    /// Return the status read from the modules.
+    pub fn status(&self) -> &[ExtendedStatus] {
         &self.data
     }
 }

--- a/controller/src/results.rs
+++ b/controller/src/results.rs
@@ -32,7 +32,7 @@ use transceiver_decode::PowerControl;
 use transceiver_decode::VendorInfo;
 use transceiver_messages::merge_module_data;
 use transceiver_messages::message::LedState;
-use transceiver_messages::message::Status;
+use transceiver_messages::message::StatusV2;
 use transceiver_messages::remove_module_data;
 use transceiver_messages::ModuleId;
 
@@ -102,11 +102,11 @@ impl ReadResult {
 }
 
 /// The result of accessing the status of a set of transceivers.
-pub type StatusResult = ModuleResult<Status>;
+pub type StatusResult = ModuleResult<StatusV2>;
 
 impl StatusResult {
     /// Return the status read from the modules.
-    pub fn status(&self) -> &[Status] {
+    pub fn status(&self) -> &[StatusV2] {
         &self.data
     }
 }

--- a/dtrace/trace-packets.d
+++ b/dtrace/trace-packets.d
@@ -44,6 +44,7 @@
 
 #define MESSAGE_KIND_SP_RESPONSE 2
 #define SP_RESPONSE_STATUS 2
+#define SP_RESPONSE_EXTENDED_STATUS 6
 #define SP_RESPONSE_ACK 3
 
 xcvr-ctl$target:::packet-sent
@@ -85,14 +86,16 @@ xcvr-ctl$target:::packet-received
 		message_body_variant = buf[MESSAGE_BODY_VARIANT_OFFSET];
 		if (message_body_variant == MESSAGE_KIND_SP_RESPONSE) {
 			sp_response_variant = buf[SP_RESPONSE_VARIANT_OFFSET];
-			if ((sp_response_variant == SP_RESPONSE_STATUS) || (sp_response_variant == SP_RESPONSE_ACK))
-            {
+			if ((sp_response_variant == SP_RESPONSE_STATUS) ||
+				(sp_response_variant == SP_RESPONSE_EXTENDED_STATUS) ||
+				(sp_response_variant == SP_RESPONSE_ACK))
+			{
 				printf("  module IDs:\n");
 				tracemem(buf + MODULE_ID_OFFSET, 16);
 				n_octets = n_bytes - STATUS_DATA_OFFSET;
 				data = (buf + STATUS_DATA_OFFSET);
 				printf("  data (up to %d octets): ", n_octets);
-				tracemem(data, 64, n_octets);
+				tracemem(data, 128, n_octets);
 			}
 		}
 	}

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transceiver-messages"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -526,10 +526,7 @@ impl SpResponse {
                 Some(modules.selected_transceiver_count() * core::mem::size_of::<Status>())
             }
             SpResponse::ExtendedStatus { modules, .. } => {
-                // NOTE: We don't `hubpack::deserialize` the `Status` objects,
-                // those are directly constructed using `Status::from_bits()`.
-                // So using `size_of` is appropriate here.
-                Some(modules.selected_transceiver_count() * core::mem::size_of::<ExtendedStatus>())
+                Some(modules.selected_transceiver_count() * ExtendedStatus::MAX_SIZE)
             }
             SpResponse::LedState { modules, .. } => {
                 Some(modules.selected_transceiver_count() * LedState::MAX_SIZE)

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -784,6 +784,12 @@ impl fmt::Display for ExtendedStatus {
     }
 }
 
+impl From<Status> for ExtendedStatus {
+    fn from(s: Status) -> Self {
+        Self::from_bits(s.bits() as u32).expect("Status must be a subset of ExtendedStatus")
+    }
+}
+
 impl core::str::FromStr for ExtendedStatus {
     type Err = bitflags::parser::ParseError;
 
@@ -1417,5 +1423,12 @@ mod test {
         }
 
         check_invalid_variants::<HostRequest>(u8::try_from(test_data.len()).unwrap());
+    }
+
+    #[test]
+    fn test_extended_status() {
+        // Test that ExtendedStatus is a superset of Status by converting
+        // Status::all, which panics if this isn't the case.
+        let _e: ExtendedStatus = Status::all().into();
     }
 }

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -53,7 +53,10 @@ pub mod version {
     pub mod inner {
         pub const V1: u8 = 1;
         pub const V2: u8 = 2;
-        pub const CURRENT: u8 = V2;
+
+        /// Includes `StatusV2` and `clear_disabled_latch`
+        pub const V3: u8 = 3;
+        pub const CURRENT: u8 = V3;
         pub const MIN: u8 = V1;
     }
     pub mod outer {
@@ -126,6 +129,10 @@ pub enum HwError {
     /// An error interacting with a board FPGA to operate on the transceivers.
     #[cfg_attr(any(test, feature = "std"), error("Error interacting with FPGA"))]
     FpgaError,
+
+    /// The module has been disabled by the SP due to a policy violation
+    #[cfg_attr(any(test, feature = "std"), error("Port is disabled by the SP"))]
+    DisabledBySp,
 }
 
 /// Deserialize the [`HwError`]s from a packet buffer that are expected, given
@@ -379,6 +386,12 @@ pub enum HostRequest {
         /// The state to set each module's LED to.
         state: LedState,
     },
+
+    /// Request to return the extended status of the transceiver modules.
+    StatusV2(ModuleId),
+
+    /// Clears the disabled latch for the given modules
+    ClearDisableLatch(ModuleId),
 }
 
 impl HostRequest {
@@ -455,7 +468,8 @@ pub enum SpResponse {
     },
 
     /// A generic acknowledgement of a specific message, where no further data
-    /// is required from the SP.
+    /// is required from the SP.  Errors are included in the trailing packet
+    /// space.
     Ack {
         /// The modules which successfully performed the requested operation.
         modules: ModuleId,
@@ -477,6 +491,23 @@ pub enum SpResponse {
         /// The modules on which fetching the LED state failed.
         failed_modules: ModuleId,
     },
+
+    /// The extended status of a set of transceiver modules.
+    ///
+    /// Each module may have a different set of status flags set. The
+    /// [`Message`] type contains the mask identifying all the modules, and the
+    /// remaining bytes of the UDP packet are a list of [`StatusV2`] objects for
+    /// each module specified.
+    ///
+    /// The ordering of the status objects is from lowest index to highest --
+    /// that is, taking the output of the returned `ModuleId::to_indices()`
+    /// method.
+    StatusV2 {
+        /// The modules whose status was successfully read.
+        modules: ModuleId,
+        /// The modules on which fetching the status failed.
+        failed_modules: ModuleId,
+    },
 }
 
 impl SpResponse {
@@ -494,6 +525,12 @@ impl SpResponse {
                 // So using `size_of` is appropriate here.
                 Some(modules.selected_transceiver_count() * core::mem::size_of::<Status>())
             }
+            SpResponse::StatusV2 { modules, .. } => {
+                // NOTE: We don't `hubpack::deserialize` the `Status` objects,
+                // those are directly constructed using `Status::from_bits()`.
+                // So using `size_of` is appropriate here.
+                Some(modules.selected_transceiver_count() * core::mem::size_of::<StatusV2>())
+            }
             SpResponse::LedState { modules, .. } => {
                 Some(modules.selected_transceiver_count() * LedState::MAX_SIZE)
             }
@@ -509,6 +546,7 @@ impl SpResponse {
             SpResponse::Read { failed_modules, .. }
             | SpResponse::Write { failed_modules, .. }
             | SpResponse::Status { failed_modules, .. }
+            | SpResponse::StatusV2 { failed_modules, .. }
             | SpResponse::Ack { failed_modules, .. }
             | SpResponse::LedState { failed_modules, .. } => {
                 Some(failed_modules.selected_transceiver_count() * HwError::MAX_SIZE)
@@ -679,6 +717,132 @@ impl SerializedSize for Status {
     const MAX_SIZE: usize = core::mem::size_of::<Status>();
 }
 
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    pub struct StatusV2: u32 {
+        /// The module is present in the receptacle.
+        ///
+        /// This translates to the `ModPrsL` pin in SFF-8679 rev 1.8 section
+        /// 5.3.4.
+        const PRESENT               = 0b0000_0000_0001;
+
+        /// The module's power is enabled.
+        ///
+        /// Note that this is not part of the QSFP specification, but provided
+        /// by the Sidecar board design itself.
+        const ENABLED               = 0b0000_0000_0010;
+
+        /// The module is held in reset.
+        ///
+        /// This translates to the `ResetL` pin in SFF-8679 rev 1.8 section
+        /// 5.3.2.
+        const RESET                 = 0b0000_0000_0100;
+
+        /// The module is held in low-power mode.
+        ///
+        /// This translates to the `ResetL` pin in SFF-8679 rev 1.8 section
+        /// 5.3.3.
+        const LOW_POWER_MODE        = 0b0000_0000_1000;
+
+        /// At least one interrupt is signaled on the module. The details of the
+        /// interrupt cause can be queried by reading various bytes of the QSFP
+        /// memory map, such as bytes 3-21 in the lower memory page. See
+        /// SFF-8636 rev 2.10a section 6.2.3 for details.
+        ///
+        /// This translates to the `IntL` pin in SFF-8679 rev 1.8 section
+        /// 5.3.5.
+        const INTERRUPT             = 0b0000_0001_0000;
+
+        /// This module's power supply has come up successfully.
+        ///
+        /// Note that this is not part of the QSFP specification, but provided
+        /// by the Sidecar board design itself.
+        const POWER_GOOD            = 0b0000_0010_0000;
+
+        /// This module's power supply has not come up after being enabled.
+        ///
+        /// Note that this is not part of the QSFP specification, but provided
+        /// by the Sidecar board design itself.
+        const FAULT_POWER_TIMEOUT   = 0b0000_0100_0000;
+
+        /// This module unexpectedly lost power.
+        ///
+        /// Note that this is not part of the QSFP specification, but provided
+        /// by the Sidecar board design itself.
+        const FAULT_POWER_LOST      = 0b0000_1000_0000;
+
+        /// The SP has disabled the port associated with this module
+        ///
+        /// This occurs if the module was initialized but is now NACKing I2C
+        /// requests for its temperature.
+        const DISABLED_BY_SP      = 0b1_0000_0000;
+    }
+}
+impl fmt::Display for StatusV2 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl core::str::FromStr for StatusV2 {
+    type Err = bitflags::parser::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
+impl Serialize for StatusV2 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u32(self.bits())
+    }
+}
+
+struct StatusV2Visitor;
+
+impl<'de> Visitor<'de> for StatusV2Visitor {
+    type Value = StatusV2;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "a single u32")
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: SerdeError,
+    {
+        u32::try_from(v)
+            .map(StatusV2::from_bits_truncate)
+            .map_err(|_| SerdeError::invalid_value(Unexpected::Unsigned(v), &self))
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: SerdeError,
+    {
+        StatusV2::from_bits(v).ok_or(SerdeError::invalid_value(
+            Unexpected::Unsigned(u64::from(v)),
+            &self,
+        ))
+    }
+}
+
+impl<'de> Deserialize<'de> for StatusV2 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_u32(StatusV2Visitor)
+    }
+}
+
+impl SerializedSize for StatusV2 {
+    const MAX_SIZE: usize = core::mem::size_of::<StatusV2>();
+}
+
 /// The state of a module's attention LED, on the Sidecar front IO panel.
 #[derive(
     Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, SerializedSize,
@@ -731,6 +895,7 @@ mod test {
     use crate::message::ProtocolError;
     use crate::message::SpResponse;
     use crate::message::Status;
+    use crate::message::StatusV2;
     use crate::mgmt::sff8636;
     use crate::mgmt::ManagementInterface;
     use crate::mgmt::MemoryRead;
@@ -806,10 +971,11 @@ mod test {
     #[test]
     fn test_hardware_error_encoding_unchanged() {
         let mut buf = [0u8; HwError::MAX_SIZE];
-        const TEST_DATA: [HwError; 3] = [
+        const TEST_DATA: [HwError; 4] = [
             HwError::I2cError,
             HwError::InvalidModuleIndex,
             HwError::FpgaError,
+            HwError::DisabledBySp,
         ];
 
         for (variant_id, variant) in TEST_DATA.iter().enumerate() {
@@ -942,7 +1108,7 @@ mod test {
         // constructors.
         let modules = ModuleId::empty();
         let failed_modules = ModuleId::empty();
-        let test_data: [SpResponse; 6] = [
+        let test_data: [SpResponse; 7] = [
             SpResponse::Read {
                 modules,
                 failed_modules,
@@ -963,6 +1129,10 @@ mod test {
             },
             SpResponse::MacAddrs(MacAddrResponse::Ok(MacAddrs::new([0; 6], 1, 1).unwrap())),
             SpResponse::LedState {
+                modules,
+                failed_modules,
+            },
+            SpResponse::StatusV2 {
                 modules,
                 failed_modules,
             },
@@ -1044,6 +1214,9 @@ mod test {
 
         let request = HostRequest::Status(ModuleId(1));
         assert_eq!(request.expected_data_len(), None);
+
+        let request = HostRequest::StatusV2(ModuleId(1));
+        assert_eq!(request.expected_data_len(), None);
     }
 
     #[test]
@@ -1085,6 +1258,15 @@ mod test {
             failed_modules: ModuleId::empty(),
         };
         assert_eq!(request.expected_data_len(), None);
+
+        let request = SpResponse::StatusV2 {
+            modules: ModuleId(1),
+            failed_modules: ModuleId::empty(),
+        };
+        assert_eq!(
+            request.expected_data_len(),
+            Some(core::mem::size_of::<StatusV2>())
+        );
     }
 
     #[test]
@@ -1168,7 +1350,7 @@ mod test {
         // This is not const because `Memory{Read,Write}` don't have const
         // constructors.
         let modules = ModuleId::empty();
-        let test_data: [HostRequest; 14] = [
+        let test_data: [HostRequest; 16] = [
             HostRequest::Read {
                 modules,
                 read: MemoryRead::new(sff8636::Page::Lower, 0, 1).unwrap(),
@@ -1195,6 +1377,8 @@ mod test {
                 modules,
                 state: LedState::Off,
             },
+            HostRequest::StatusV2(modules),
+            HostRequest::ClearDisableLatch(modules),
         ];
 
         for (variant_id, variant) in test_data.iter().enumerate() {

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -773,7 +773,7 @@ bitflags::bitflags! {
 
         /// The SP has disabled the port associated with this module
         ///
-        /// For example, this could occurs if the module was initialized but is
+        /// For example, this could occur if the module was initialized but is
         /// now NACKing I2C requests for its temperature.
         const DISABLED_BY_SP      = 0b1_0000_0000;
     }

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -786,6 +786,8 @@ impl fmt::Display for ExtendedStatus {
 
 impl From<Status> for ExtendedStatus {
     fn from(s: Status) -> Self {
+        // The requirement that Status is a subset of ExtendedStatus is checked
+        // in a unit test below (`test_extended_status`)
         Self::from_bits(s.bits() as u32).expect("Status must be a subset of ExtendedStatus")
     }
 }


### PR DESCRIPTION
This PR adds support for ports disabled by Hubris (see https://github.com/oxidecomputer/hubris/pull/1441)

- Adds a wider `StatusV2` type and message, which includes a bit for `DISABLED_BY_SP` (and 23 spare bits, just in case)
- Uses the `StatusV2` message in `xcvradm`
- Adds `HwError::DisabledBySp` and `HostRequest::ClearDisableLatch`

Before merging:
- Test on an actual Sidecar
- Bikeshedding about `StatusV2` (perhaps `ExtendedStatus`?  Or rename `Status` -> `HwStatus` and reclaim `Status`?), `HwError::DisabledBySp` and `HostRequest::ClearDisableLatch`, since I don't love any of those names
- Is this going to break anything that calls into `xcvradm`, since it changes types from `Status` -> `StatusV2` in a few places?