### PR TITLE
Break large memory accesses into chunks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ default-members = [
     "decode",
     "messages",
 ]
+
+resolver = "2"

--- a/controller/src/large_access.rs
+++ b/controller/src/large_access.rs
@@ -1,0 +1,183 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! Trait for splitting large memory accesses into chunks.
+//!
+//! The CMIS specification for accessing transceiver memory maps clearly
+//! indicates that accesses must be limited in size. Unless otherwise noted,
+//! accesses can be no larger than 8 octets. (See CMIS 5.0, section 5.2.2.1 for
+//! more details.) While the SFF-8636 specification doesn't explicitly limit the
+//! size of an access, experimentation with real transceivers shows that very
+//! large accesses (128 bytes, for example) can generate I2C errors.
+//!
+//! This module contains a trait for describing an arbitrary-sized memory
+//! access, and splitting that up into fixed-sized chunks of appropriate size.
+//! For CMIS modules, the size is 8 octets. For SFF-8636 modules, the size is
+//! currently limited to 64 octets, a value chosen through experimentation.
+
+use crate::mgmt;
+use crate::mgmt::MemoryPage;
+use crate::Error;
+
+/// A trait for splitting an arbitrary-sized access into limited chunks.
+pub trait LargeMemoryAccess<P>: Sized
+where
+    P: MemoryPage,
+    mgmt::Page: From<P>,
+{
+    /// The size of a single memory access chunk, in octets.
+    const SIZE: u8;
+
+    /// A dummy type asserting that the `SIZE` constant is valid.
+    const _DUMMY: () = assert!(Self::SIZE > 0 && Self::SIZE <= 128);
+
+    /// Return a single memory access of the provided size.
+    fn build_one(page: P, offset: u8, len: u8) -> Result<Self, Error>;
+
+    /// Split a single large access into many, using `Self::build_one()`.
+    fn build_many(page: P, offset: u8, len: u8) -> Result<Vec<Self>, Error> {
+        let end = offset + len;
+        (offset..end)
+            .step_by(usize::from(Self::SIZE))
+            .map(|new_offset| {
+                // The length is up to SIZE, or the remainder of the entire
+                // operation, whichever is smaller.
+                let remainder = end - new_offset;
+                let new_len = Self::SIZE.min(remainder);
+                Self::build_one(page, new_offset, new_len)
+            })
+            .collect()
+    }
+}
+
+impl LargeMemoryAccess<mgmt::sff8636::Page> for mgmt::MemoryRead {
+    // TODO-correctness: Empirically this works fine, but not based on the spec.
+    const SIZE: u8 = 64;
+
+    fn build_one(page: mgmt::sff8636::Page, offset: u8, len: u8) -> Result<Self, Error> {
+        Self::new(page, offset, len).map_err(Error::from)
+    }
+}
+
+impl LargeMemoryAccess<mgmt::sff8636::Page> for mgmt::MemoryWrite {
+    // TODO-correctness: Empirically this works fine, but not based on the spec.
+    const SIZE: u8 = 64;
+
+    fn build_one(page: mgmt::sff8636::Page, offset: u8, len: u8) -> Result<Self, Error> {
+        Self::new(page, offset, len).map_err(Error::from)
+    }
+}
+
+impl LargeMemoryAccess<mgmt::cmis::Page> for mgmt::MemoryRead {
+    const SIZE: u8 = mgmt::cmis::Page::MAX_READ_SIZE;
+
+    fn build_one(page: mgmt::cmis::Page, offset: u8, len: u8) -> Result<Self, Error> {
+        Self::new(page, offset, len).map_err(Error::from)
+    }
+}
+
+impl LargeMemoryAccess<mgmt::cmis::Page> for mgmt::MemoryWrite {
+    const SIZE: u8 = mgmt::cmis::Page::MAX_WRITE_SIZE;
+
+    fn build_one(page: mgmt::cmis::Page, offset: u8, len: u8) -> Result<Self, Error> {
+        Self::new(page, offset, len).map_err(Error::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mgmt;
+    use super::LargeMemoryAccess;
+    use super::MemoryPage;
+
+    #[test]
+    fn test_build_large_memory_access_even_split() {
+        test_build_large_memory_access_even_split_impl::<mgmt::MemoryRead, mgmt::cmis::Page>(
+            mgmt::cmis::Page::Lower,
+        );
+        test_build_large_memory_access_even_split_impl::<mgmt::MemoryWrite, mgmt::cmis::Page>(
+            mgmt::cmis::Page::Lower,
+        );
+        test_build_large_memory_access_even_split_impl::<mgmt::MemoryRead, mgmt::sff8636::Page>(
+            mgmt::sff8636::Page::Lower,
+        );
+        test_build_large_memory_access_even_split_impl::<mgmt::MemoryWrite, mgmt::sff8636::Page>(
+            mgmt::sff8636::Page::Lower,
+        );
+    }
+
+    fn test_build_large_memory_access_even_split_impl<T, P>(page: P)
+    where
+        T: LargeMemoryAccess<P>,
+        P: MemoryPage,
+        mgmt::Page: From<P>,
+        mgmt::MemoryRead: LargeMemoryAccess<P>,
+    {
+        let offset = 0;
+        let len = 64;
+        let reads = mgmt::MemoryRead::build_many(page, offset, len)
+            .expect("failed to build multiple accesses");
+        assert_eq!(reads.len(), usize::from(len / T::SIZE));
+
+        for (read, expected_offset) in reads.into_iter().zip((0..).step_by(T::SIZE as _)) {
+            assert_eq!(read.offset(), expected_offset);
+            assert_eq!(read.len(), T::SIZE);
+            assert_eq!(read.page(), &mgmt::Page::from(page));
+        }
+    }
+
+    #[test]
+    fn test_build_large_memory_accessad_uneven_split() {
+        test_build_large_memory_access_uneven_split_impl::<mgmt::MemoryRead, mgmt::cmis::Page>(
+            mgmt::cmis::Page::Lower,
+        );
+        test_build_large_memory_access_uneven_split_impl::<mgmt::MemoryWrite, mgmt::cmis::Page>(
+            mgmt::cmis::Page::Lower,
+        );
+        test_build_large_memory_access_uneven_split_impl::<mgmt::MemoryRead, mgmt::sff8636::Page>(
+            mgmt::sff8636::Page::Lower,
+        );
+        test_build_large_memory_access_uneven_split_impl::<mgmt::MemoryWrite, mgmt::sff8636::Page>(
+            mgmt::sff8636::Page::Lower,
+        );
+    }
+
+    fn test_build_large_memory_access_uneven_split_impl<T, P>(page: P)
+    where
+        T: LargeMemoryAccess<P>,
+        P: MemoryPage,
+        mgmt::Page: From<P>,
+        mgmt::MemoryRead: LargeMemoryAccess<P>,
+    {
+        let offset = 0;
+        let len = 63;
+        let reads = mgmt::MemoryRead::build_many(page, offset, len)
+            .expect("failed to build multiple accesses");
+        assert_eq!(reads.len(), usize::from(len / T::SIZE) + 1);
+
+        for (i, (read, expected_offset)) in
+            reads.iter().zip((0..).step_by(T::SIZE as _)).enumerate()
+        {
+            // The first N - 1 should be full reads, and the last exactly the
+            // remaining bytes.
+            let expected_len = if i < (reads.len() - 1) {
+                T::SIZE
+            } else {
+                T::SIZE - 1
+            };
+            assert_eq!(read.offset(), expected_offset);
+            assert_eq!(read.len(), expected_len);
+            assert_eq!(read.page(), &mgmt::Page::from(page));
+        }
+
+        // The sum of all the sizes should be exactly the original length.
+        assert_eq!(
+            reads.iter().map(|read| read.len()).sum::<u8>(),
+            len,
+            "All reads need to sum to the full expected size",
+        );
+    }
+}

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -62,6 +62,7 @@
 mod config;
 mod controller;
 mod ioloop;
+mod large_access;
 mod messages;
 mod results;
 
@@ -69,6 +70,7 @@ pub use crate::config::*;
 pub use crate::controller::Controller;
 pub use crate::messages::*;
 pub use crate::results::*;
+pub use large_access::LargeMemoryAccess;
 
 use std::net::IpAddr;
 pub use transceiver_decode::Error as DecodeError;

--- a/messages/src/module_id.rs
+++ b/messages/src/module_id.rs
@@ -161,6 +161,11 @@ impl ModuleId {
     pub const fn contains(&self, ix: u8) -> bool {
         (self.0 & (1 << ix)) != 0
     }
+
+    /// Return `true` if the other set of IDs is a subset of `self`.
+    pub const fn is_subset(&self, other: &Self) -> bool {
+        self.0 == (self.0 | other.0)
+    }
 }
 
 impl BitAnd for ModuleId {
@@ -488,5 +493,15 @@ mod tests {
 
         assert_eq!(a & 0b010_u64, ModuleId::empty());
         assert_eq!(a | 0b010_u64, ModuleId(0b111));
+    }
+
+    #[test]
+    fn test_is_subset() {
+        assert!(!ModuleId(0b101).is_subset(&ModuleId(0b010)));
+        assert!(!ModuleId(0b010).is_subset(&ModuleId(0b101)));
+
+        assert!(ModuleId(0b0).is_subset(&ModuleId(0b0)));
+        assert!(ModuleId(0b1).is_subset(&ModuleId(0b1)));
+        assert!(ModuleId(0b111).is_subset(&ModuleId(0b1)));
     }
 }


### PR DESCRIPTION
- Add the `LargeMemoryAccess` trait, which describes how to break a single large memory access, which may violate a transceiver's management spec, into smaller chunks. This is mostly ported directly from Dendrite, which already included this trait and tests for it.
- Use the large memory access trait to support _reads_ in `xcvradm` that are larger than the chunk-size limit.
- Add methods for appending a module result into another, where those results return an _array_ of items for each module. This is the case for the read operations, which return a byte array for each module.
- Add tests for the append operation