### PR TITLE
Add support for decoding transceiver datapath state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,7 +172,7 @@ version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -316,6 +322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +364,12 @@ dependencies = [
  "plain",
  "scroll",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -516,6 +534,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "papergrid"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7419ad52a7de9b60d33e11085a0fe3df1fbd5926aa3f93d3dd53afbc9e86725"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "pest"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +612,30 @@ name = "pretty-hex"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -805,6 +858,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +889,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tabled"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c9303ee60b9bedf722012ea29ae3711ba13a67c9b9ae28993838b63057cb1b"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0fb8bfdc709786c154e24a66777493fb63ae97e3036d914c8666774c477069"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -994,6 +1076,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
+ "tabled",
  "tempfile",
  "thiserror 2.0.6",
  "tokio",
@@ -1010,6 +1093,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "static_assertions",
  "thiserror 2.0.6",
  "transceiver-messages",
 ]
@@ -1044,6 +1128,12 @@ name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "usdt"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -14,6 +14,7 @@ itertools = "0.13.0"
 serde = "1"
 slog-async = "2"
 slog-term = "2"
+tabled = "0.16"
 thiserror = "2"
 transceiver-decode = { path = "../decode", default-features = false }
 transceiver-messages = { path = "../messages" }

--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -1554,8 +1554,8 @@ fn print_cmis_datapath(
                     .map(|p| p.to_string())
                     .unwrap_or_else(|| String::from("Unsupported"))
             }),
-            ("Rx input polarity", |st| {
-                st.tx_input_polarity
+            ("Rx output polarity", |st| {
+                st.rx_output_polarity
                     .map(|p| p.to_string())
                     .unwrap_or_else(|| String::from("Unsupported"))
             }),

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -31,6 +31,7 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
+use transceiver_decode::Datapath;
 use transceiver_decode::Error as DecodeError;
 use transceiver_decode::Identifier;
 use transceiver_decode::MemoryModel;
@@ -45,23 +46,19 @@ use transceiver_messages::merge_module_data;
 use transceiver_messages::message;
 use transceiver_messages::message::Header;
 use transceiver_messages::message::HostRequest;
-pub use transceiver_messages::message::HwError;
 pub use transceiver_messages::message::LedState;
 use transceiver_messages::message::MacAddrResponse;
 use transceiver_messages::message::Message;
 use transceiver_messages::message::MessageBody;
 use transceiver_messages::message::MessageKind;
-pub use transceiver_messages::message::ProtocolError;
 use transceiver_messages::message::SpResponse;
 pub use transceiver_messages::message::Status;
-pub use transceiver_messages::mgmt;
 use transceiver_messages::mgmt::sff8636;
 use transceiver_messages::mgmt::ManagementInterface;
 use transceiver_messages::mgmt::MemoryRead;
 use transceiver_messages::mgmt::MemoryWrite;
 use transceiver_messages::mgmt::Page;
 use transceiver_messages::remove_module_data;
-pub use transceiver_messages::InvalidPort;
 pub use transceiver_messages::ModuleId;
 use transceiver_messages::MAX_PAYLOAD_SIZE;
 
@@ -1157,6 +1154,11 @@ impl Controller {
     /// Return the monitoring information of a set of modules.
     pub async fn monitors(&self, modules: ModuleId) -> Result<MonitorResult, Error> {
         self.parse_modules_by_identifier::<Monitors>(modules).await
+    }
+
+    /// Return the datapath state for a set of modules.
+    pub async fn datapath(&self, modules: ModuleId) -> Result<DatapathResult, Error> {
+        self.parse_modules_by_identifier::<Datapath>(modules).await
     }
 
     // Parse a decodable piece of data from each module.

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! A host-side control interface to the SP for managing Sidecar transceivers.
 //!
@@ -47,17 +47,14 @@
 //! DTrace provider `xcvr_ctl`, and the probes are:
 //!
 //! - `bad-message` fires when a message is received that could not be
-//! deserialized or was unexpected, for example violating the protocol. It
-//! contains the peer and reason for the failure.
+//!   deserialized or was unexpected, for example violating the protocol. It
+//!   contains the peer and reason for the failure.
 //! - `message-received` fires when a valid message is received, with the peer
-//! and actual message as data.
+//!   and actual message as data.
 //! - `message-sent` fires when a message is sent, with the peer it's sent to
-//! and the actual message as data.
+//!   and the actual message as data.
 //! - `packet-sent` and `packet-received` fire when any UDP packet is sent and
-//! received, with the address and a pointer to the raw data.
-
-#![cfg_attr(not(usdt_stable_asm), feature(asm))]
-#![cfg_attr(all(target_os = "macos", not(usdt_stable_asm_sym)), feature(asm_sym))]
+//!   received, with the address and a pointer to the raw data.
 
 mod config;
 mod controller;

--- a/controller/src/results.rs
+++ b/controller/src/results.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! Types for handling data returned by accessing multiple modules.
 //!
@@ -26,6 +26,7 @@
 use crate::PowerMode;
 use crate::TransceiverError;
 use std::collections::BTreeMap;
+use transceiver_decode::Datapath;
 use transceiver_decode::Identifier;
 use transceiver_decode::MemoryModel;
 use transceiver_decode::Monitors;
@@ -203,6 +204,9 @@ pub type LedStateResult = ModuleResult<LedState>;
 /// The result of reading the monitoring data of a set of transceivers.
 pub type MonitorResult = ModuleResult<Monitors>;
 
+/// The result of reading the datapath state of a set of transceivers.
+pub type DatapathResult = ModuleResult<Datapath>;
+
 /// A generic type for accessing module-specific data and failures.
 ///
 /// Many methods access multiple modules, and may return a piece of data for
@@ -278,8 +282,8 @@ impl<P: Clone> ModuleResult<P> {
     /// This returns `None` if any of the following occur:
     ///
     /// - `other.modules` and `self.modules` overlap. In this case, it is not
-    /// possible to build a consistent result, since we have two values for the
-    /// successful data.
+    ///   possible to build a consistent result, since we have two values for the
+    ///   successful data.
     /// - `other.failures` and `self.failures` overlap, for the same reason.
     ///
     /// Note that if a module exists in `other.failures.modules` and

--- a/decode/Cargo.toml
+++ b/decode/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 api-traits = [ "dep:schemars", "dep:serde" ]
 
 [dependencies]
+static_assertions = "1.1.0"
 transceiver-messages = { path = "../messages", features = [ "std" ] }
 thiserror = "2"
 

--- a/decode/src/datapath.rs
+++ b/decode/src/datapath.rs
@@ -1,0 +1,1064 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2024 Oxide Computer Company
+
+//! Decode module datapath state.
+
+use crate::utils::extract_bit;
+use crate::Error;
+use crate::ExtendedSpecificationComplianceCode;
+use crate::HostElectricalInterfaceId;
+use crate::Identifier;
+use crate::MediaInterfaceId;
+use crate::MediaType;
+use crate::ParseFromModule;
+use std::collections::BTreeMap;
+use std::fmt;
+use transceiver_messages::mgmt::cmis;
+use transceiver_messages::mgmt::sff8636;
+use transceiver_messages::mgmt::MemoryRead;
+
+/// Information about a transceiver's datapath.
+///
+/// This includes state related to the low-level eletrical and optical path
+/// through which bits flow. This includes flags like loss-of-signal /
+/// loss-of-lock; transmitter enablement state; and equalization parameters.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+#[cfg_attr(any(feature = "api-traits", test), serde(rename_all = "snake_case"))]
+pub enum Datapath {
+    /// A number of datapaths in a CMIS module.
+    ///
+    /// CMIS modules may have a large number of supported configurations of
+    /// their various lanes, each called an "application". These are described
+    /// by the `ApplicationDescriptor` type, which mirrors CMIS 5.0 table 8-18.
+    /// Each descriptor is identified by an "Application Selector Code", which
+    /// is just its index in the section of the memory map describing them.
+    ///
+    /// Each lane can be used in zero or more applications, however, it may
+    /// exist in at most one application at a time. These active applications,
+    /// of which there may be more than one, are keyed by their codes in the
+    /// contained mapping.
+    Cmis {
+        /// The type of free-side connector
+        connector: ConnectorType,
+        /// A bit mask with a 1 in bit `i` if the `i`th lane is supported.
+        supported_lanes: u8,
+        /// Mapping from "application selector" ID to its datapath information.
+        ///
+        /// The datapath inclues the lanes used; host electrical interface;
+        /// media interface; and a lot more about the state of the path.
+        datapaths: BTreeMap<u8, CmisDatapath>,
+    },
+    /// Datapath state about each lane in an SFF-8636 module.
+    Sff8636 {
+        connector: ConnectorType,
+        specification: SffComplianceCode,
+        lanes: [Sff8636Datapath; 4],
+    },
+}
+
+/// The type of a media-side connector.
+///
+/// These values come from SFF-8024 Rev 4.10 Table 4-3
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+#[cfg_attr(any(feature = "api-traits", test), serde(rename_all = "snake_case"))]
+pub enum ConnectorType {
+    Unknown,
+    SubscriberConnector,
+    LucentConnector,
+    Mpo1x12,
+    Mpo2x16,
+    Rj45,
+    Mpo2x12,
+    Mpo1x16,
+    Other(u8),
+    Reserved(u8),
+    VendorSpecific(u8),
+}
+
+impl From<u8> for ConnectorType {
+    fn from(value: u8) -> Self {
+        use ConnectorType::*;
+        match value {
+            0x00 => Unknown,
+            0x01 => SubscriberConnector,
+            0x07 => LucentConnector,
+            0x0c => Mpo1x12,
+            0x0d => Mpo2x16,
+            0x22 => Rj45,
+            0x27 => Mpo2x12,
+            0x28 => Mpo1x16,
+            0x0e..=0x1f | 0x29..=0x7f => Reserved(value),
+            0x80..=0xff => VendorSpecific(value),
+            x => Other(x),
+        }
+    }
+}
+
+impl fmt::Display for ConnectorType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ConnectorType::Unknown => write!(f, "Unknown"),
+            ConnectorType::SubscriberConnector => write!(f, "Subscriber Connector"),
+            ConnectorType::LucentConnector => write!(f, "Lucent Connector (LC)"),
+            ConnectorType::Mpo1x12 => write!(f, "MPO 1x12"),
+            ConnectorType::Mpo2x16 => write!(f, "MPO 2x16"),
+            ConnectorType::Rj45 => write!(f, "RJ-45"),
+            ConnectorType::Mpo2x12 => write!(f, "MPO-2x12"),
+            ConnectorType::Mpo1x16 => write!(f, "MPO-1x16"),
+            ConnectorType::Other(x) => write!(f, "Other ({x:02x})"),
+            ConnectorType::Reserved(x) => write!(f, "Reserved ({x:02x})"),
+            ConnectorType::VendorSpecific(x) => write!(f, "Vendor-specific ({x:02x})"),
+        }
+    }
+}
+
+/// The compliance code for an SFF-8636 module.
+///
+/// These values record a specification compliance code, from SFF-8636 Table
+/// 6-17, or an extended specification compliance code, from SFF-8024 Table 4-4.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+#[cfg_attr(any(feature = "api-traits", test), serde(rename_all = "snake_case"))]
+pub enum SffComplianceCode {
+    Extended(ExtendedSpecificationComplianceCode),
+    Ethernet(u8),
+}
+
+impl fmt::Display for SffComplianceCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Extended(ext) => write!(f, "{}", ext),
+            Self::Ethernet(x) => match x {
+                0b0000_0001 => write!(f, "40G Active Cable"),
+                0b0000_0010 => write!(f, "40GBASE-LR4"),
+                0b0000_0100 => write!(f, "40GBASE-SR4"),
+                0b0000_1000 => write!(f, "40GBASE-CR4"),
+                0b0001_0000 => write!(f, "10GBASE-SR"),
+                0b0010_0000 => write!(f, "10GBASE-LR"),
+                0b0100_0000 => write!(f, "10GBASE-LRM"),
+                _ => unreachable!(),
+            },
+        }
+    }
+}
+
+impl SffComplianceCode {
+    /// Decode specification compliance, from the core specification and
+    /// possibly the extended specification compliance byte.
+    pub fn new(specification: u8, extended_specification: u8) -> Self {
+        if specification == 0x80 {
+            Self::Extended(ExtendedSpecificationComplianceCode::from(
+                extended_specification,
+            ))
+        } else {
+            Self::Ethernet(specification)
+        }
+    }
+}
+
+impl ParseFromModule for Datapath {
+    fn reads(id: Identifier) -> Result<Vec<MemoryRead>, Error> {
+        match id {
+            Identifier::QsfpPlusSff8636 | Identifier::Qsfp28 => {
+                let tx_enable = MemoryRead::new(sff8636::Page::Lower, 86, 1)?;
+                let los = MemoryRead::new(sff8636::Page::Lower, 3, 3)?;
+                let cdr = MemoryRead::new(sff8636::Page::Lower, 98, 1)?;
+                let compliance =
+                    MemoryRead::new(sff8636::Page::Upper(sff8636::UpperPage::new(0)?), 130, 2)?;
+                let extended_compliance =
+                    MemoryRead::new(sff8636::Page::Upper(sff8636::UpperPage::new(0)?), 192, 1)?;
+                Ok(vec![tx_enable, los, cdr, compliance, extended_compliance])
+            }
+            Identifier::QsfpPlusCmis | Identifier::QsfpDD => {
+                // As with most module data, CMIS is _far_ more complicated than
+                // SFF-8636. Lanes can be assigned to different datapaths,
+                // though only one at a time, and modules can have a large
+                // number of different datapaths. Each is described by an
+                // `ApplicationDescriptor`, which defines the host / media
+                // interfaces; lane assignments; and number of lanes.
+                //
+                // We'll start by reading the connector type, which is the same
+                // for all lanes, and the list of supported lanes. These fit in
+                // one read.
+                let connector_type = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_unbanked(0x00)?),
+                    203,
+                    7,
+                )?;
+
+                // Read the configuration for each lane. Table 8-83.
+                //
+                // For each lane, this gives indices for the datapath that uses
+                // that lane, if any. The bits of each byte are intepreted as:
+                //
+                // The upper 4 bits give the the index of the Application that
+                // this lane is part of. E.g., if this is `0b0001`, then this is
+                // part of the application with index 1. If this is all zero,
+                // the lane is unused.
+                //
+                // The next 3 bits give the index of the first lane in the
+                // datapath that contains this lane.
+                //
+                // The last bit is 1 if the SI settings for the lane can be
+                // controlled by the host, or 0 if the application defines them
+                // entirely.
+                //
+                // The lane is "active" if the index is _not_ all zeros, i.e.,
+                // this lane is in use in _some_ application.
+                let lane_config = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_banked(0x11, 0)?),
+                    206,
+                    8,
+                )?;
+
+                // Read the media type. CMIS Table 8-17.
+                let media_type = MemoryRead::new(cmis::Page::Lower, 85, 1)?;
+
+                // Read the assignments of media lanes to applications. Table
+                // 8-51.
+                //
+                // Note that we _first_ read the media assignments, which are
+                // bit-masks that are a 1 when the corresponding lane is used in
+                // the application. We read these first because they're required
+                // to understand how to decode the application descriptors,
+                // which we read next.
+                let media_assignments = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_unbanked(0x01)?),
+                    176,
+                    8,
+                )?;
+
+                // Read the application descriptors. Table 8-19.
+                //
+                // An application descriptor describes everything about an
+                // "application", which is the set of lanes and their metadata
+                // that goes into a single datapath. These values include:
+                //
+                // - Host interface ID
+                // - Media interface ID
+                // - Host lane count
+                // - Media lane count
+                // - Host lane assignment options
+                //
+                // There is always at least one application descriptor, and the
+                // end of the list is indicated by a Host interface ID of 0xFF.
+                let descriptors = (86..118)
+                    .step_by(8)
+                    .map(|start| MemoryRead::new(cmis::Page::Lower, start, 8))
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                // Read the support for various lane-specific controls. Table
+                // 8-44.
+                let control_support = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_unbanked(0x01)?),
+                    155,
+                    4,
+                )?;
+
+                // Next, read the lane-specific control bits, indicating how the
+                // host can manipulate each lane, such as disabling the
+                // transmitter.
+                //
+                // Table 8-61.
+                let controls0 = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_banked(0x10, 0)?),
+                    129,
+                    4,
+                )?;
+                let controls1 = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_banked(0x10, 0)?),
+                    134,
+                    6,
+                )?;
+
+                // Read datapath state for each datapath. Table 8-73.
+                let datapath_state = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_banked(0x11, 0)?),
+                    128,
+                    4,
+                )?;
+
+                // Read the lane-specific output status bits. Table 8-75.
+                let lane_status = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_banked(0x11, 0)?),
+                    132,
+                    2,
+                )?;
+
+                // And finally the lane-specific flags. Table 8-77.
+                let tx_lane_flags = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_banked(0x11, 0)?),
+                    135,
+                    4,
+                )?;
+                // Table 8-78.
+                let rx_lane_flags = MemoryRead::new(
+                    cmis::Page::Upper(cmis::UpperPage::new_banked(0x11, 0)?),
+                    147,
+                    2,
+                )?;
+
+                let mut reads = Vec::with_capacity(15);
+                reads.push(connector_type);
+                reads.push(lane_config);
+                reads.push(media_type);
+                reads.push(media_assignments);
+                reads.extend(descriptors);
+                reads.push(control_support);
+                reads.push(controls0);
+                reads.push(controls1);
+                reads.push(datapath_state);
+                reads.push(lane_status);
+                reads.push(tx_lane_flags);
+                reads.push(rx_lane_flags);
+                Ok(reads)
+            }
+            _ => Err(Error::UnsupportedIdentifier(id)),
+        }
+    }
+
+    fn parse<'a>(id: Identifier, mut reads: impl Iterator<Item = &'a [u8]>) -> Result<Self, Error> {
+        match id {
+            Identifier::QsfpPlusSff8636 | Identifier::Qsfp28 => {
+                let tx_enable = reads.next().unwrap();
+                assert_eq!(tx_enable.len(), 1);
+                let los = reads.next().unwrap();
+                assert_eq!(los.len(), 3);
+                let cdr = reads.next().unwrap();
+                assert_eq!(cdr.len(), 1);
+                let compliance = reads.next().unwrap();
+                assert_eq!(compliance.len(), 2);
+                let extended_compliance = reads.next().unwrap();
+                assert_eq!(extended_compliance.len(), 1);
+
+                // Extract connector type.
+                let connector = ConnectorType::from(compliance[0]);
+
+                // Extract specification compliance code.
+                let specification = SffComplianceCode::new(compliance[1], extended_compliance[0]);
+
+                // Extract data for all four lanes.
+                //
+                // It's not currently obvious how to extract the _real_ number
+                // of lanes. In contrast to CMIS, this isn't explicitly
+                // described by the memory map. We could extract it from the
+                // host-electrical ID, but that doesn't constrain it enough,
+                // since some IDs support multiple lane configurations.
+                let lanes = (0..4)
+                    .map(|lane| {
+                        // Byte 86 bits 0..3 are Tx _disabled_.
+                        let tx_enabled = !extract_bit(tx_enable[0], lane)?;
+
+                        // The LOS / LOL bits are not inverted: 1 means there is
+                        // such as state. Some of these are shifted by 4, since the
+                        // lower 4 bits are for the Rx side of things.
+                        let tx_lane = lane + 4;
+                        let tx_los = extract_bit(los[0], tx_lane)?;
+                        let tx_adaptive_eq_fault = extract_bit(los[1], tx_lane)?;
+                        let tx_fault = extract_bit(los[1], lane)?;
+                        let tx_lol = extract_bit(los[2], tx_lane)?;
+
+                        // Rx side state is in the lower 4 bits.
+                        let rx_los = extract_bit(los[0], lane)?;
+                        let rx_lol = extract_bit(los[2], lane)?;
+
+                        // Extract CDR bits.
+                        let tx_cdr_enabled = extract_bit(cdr[0], tx_lane)?;
+                        let rx_cdr_enabled = extract_bit(cdr[0], lane)?;
+
+                        Ok(Sff8636Datapath {
+                            tx_enabled,
+                            tx_los,
+                            rx_los,
+                            tx_adaptive_eq_fault,
+                            tx_fault,
+                            tx_lol,
+                            rx_lol,
+                            tx_cdr_enabled,
+                            rx_cdr_enabled,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, Error>>()?
+                    .try_into()
+                    .unwrap();
+                Ok(Datapath::Sff8636 {
+                    connector,
+                    specification,
+                    lanes,
+                })
+            }
+            Identifier::QsfpPlusCmis | Identifier::QsfpDD => {
+                // First, read the connector type and which lanes are
+                // _unsupported_.
+                let connector_type = reads.next().expect("No connector type read");
+                assert_eq!(connector_type.len(), 7);
+                let connector = ConnectorType::from(connector_type[0]);
+
+                // See CMIS 5.0 Table 8-31.
+                //
+                // Each bit is 1 when the lane is _unsupported_. We invert that
+                // to be sane.
+                let supported_lanes = !connector_type[6];
+
+                // We next read the lane configuration, which tells us which
+                // application (if any) each lane is assigned to. These are the
+                // lanes _in use_, and the set of all applications in use is the
+                // union of those any lane is assigned to.
+                let lane_config = reads.next().expect("No datapath lane configuration read");
+                assert_eq!(lane_config.len(), 8);
+                let lane_configs: Vec<_> =
+                    lane_config.iter().map(LaneDatapathConfig::from).collect();
+
+                // Decode media type.
+                let media_type = MediaType::from(reads.next().expect("No media type read")[0]);
+
+                // Extract the media assignment options.
+                let media_assignments =
+                    reads.next().expect("Missing media assignment options read");
+
+                // Parse out the applications themselves.
+                //
+                // These are the _supported_ applications. The active ones are
+                // defined by the application selectors that the lanes are
+                // assigned to, in each entry of `lane_configs` above.
+                //
+                // Pull out all 8 descriptors. These are 4 bytes each, which
+                // we've packed into 4 reads of 2 descriptors.
+                let mut supported_applications = Vec::with_capacity(8);
+                let mut descriptors = Vec::with_capacity(8);
+                for read in 0..4 {
+                    let descriptor = reads
+                        .next()
+                        .unwrap_or_else(|| panic!("Missing application descriptor read {read}"));
+                    descriptors.extend(descriptor.chunks_exact(4));
+                }
+                for (i, descriptor) in descriptors.into_iter().enumerate() {
+                    // Fetch the assignment of each lane for this application
+                    // ID.
+                    let assignment = media_assignments[i];
+                    let app = ApplicationDescriptor::from_bytes(
+                        media_type,
+                        descriptor.try_into().unwrap(),
+                        assignment,
+                    )
+                    .unwrap();
+
+                    // If this is the end of list, break out, otherwise push
+                    // this descriptor and continue.
+                    if app.host_id == HostElectricalInterfaceId::EndOfList {
+                        break;
+                    }
+                    supported_applications.push(app);
+                }
+
+                // Pull out the set of _active_ applications, using the lane
+                // configurations.
+                //
+                // We're creating a mapping from the application selector ID
+                // (AppSel), to a tuple of (application descriptor, array of
+                // lanes). This is so that later, we can pull out the status
+                // bits of each lane and assign it to the right datapath.
+                let mut active_applications: BTreeMap<u8, (ApplicationDescriptor, Vec<u8>)> =
+                    BTreeMap::new();
+                for (lane, lane_config) in lane_configs.into_iter().enumerate() {
+                    if lane_config.is_assigned() {
+                        let app_sel = lane_config.app_select_code;
+                        let app = supported_applications
+                            .get(usize::from(app_sel - 1))
+                            .expect("Up to 8 applications are currently supported");
+                        active_applications
+                            .entry(app_sel)
+                            .or_insert_with(|| (*app, vec![]))
+                            .1
+                            .push(lane.try_into().unwrap());
+                    }
+                }
+
+                fn supported_bit_is_set(
+                    support: u8,
+                    bit: u8,
+                    control: u8,
+                    lane: u8,
+                ) -> Option<bool> {
+                    if let Ok(true) = extract_bit(support, bit) {
+                        extract_bit(control, lane).ok()
+                    } else {
+                        None
+                    }
+                }
+
+                // For each active application, let's access the status bits of
+                // the lanes that it's composed of.
+                let support = reads.next().expect("Missing control support read");
+                let controls0 = reads.next().expect("Missing controls0 read");
+                let controls1 = reads.next().expect("Missing controls1 read");
+                let datapath_state = reads.next().expect("Missing datapath state read");
+                let lane_status = reads.next().expect("Missing lane-specific status read");
+                let tx_lane_flags = reads.next().expect("Missing Tx lane flags read");
+                let rx_lane_flags = reads.next().expect("Missing Rx lane flags read");
+                let mut datapaths = BTreeMap::new();
+                for (app_sel, (app, lanes)) in active_applications.into_iter() {
+                    for lane in lanes.into_iter() {
+                        // Most of these controls and flags are advertised in a
+                        // support word. Extract the bit itself as a boolean, if
+                        // it is supported, or None if not.
+                        //
+                        // See CMIS 5.0 section 8.4.7 for the bit definitions of
+                        // the support bits. See table 8-61 for the control
+                        // bits.
+                        let tx_input_polarity =
+                            supported_bit_is_set(support[0], 0, controls0[0], lane).map(|x| {
+                                if x {
+                                    Polarity::Flipped
+                                } else {
+                                    Polarity::Normal
+                                }
+                            });
+                        let tx_output_enabled =
+                            supported_bit_is_set(support[0], 1, controls0[1], lane).map(|x| !x);
+                        let tx_auto_squelch_disable =
+                            supported_bit_is_set(support[0], 2, controls0[2], lane);
+                        let tx_force_squelch =
+                            supported_bit_is_set(support[0], 3, controls0[3], lane);
+                        let rx_output_polarity =
+                            supported_bit_is_set(support[1], 0, controls1[3], lane).map(|x| {
+                                if x {
+                                    Polarity::Flipped
+                                } else {
+                                    Polarity::Normal
+                                }
+                            });
+                        let rx_output_enabled =
+                            supported_bit_is_set(support[1], 1, controls1[4], lane).map(|x| !x);
+                        let rx_auto_squelch_disable =
+                            supported_bit_is_set(support[1], 2, controls1[5], lane);
+
+                        // The output status bits are required by the spec.
+                        let rx_output_status = if lane_status[0] & (1 << lane) != 0 {
+                            OutputStatus::Valid
+                        } else {
+                            OutputStatus::Invalid
+                        };
+                        let tx_output_status = if lane_status[1] & (1 << lane) != 0 {
+                            OutputStatus::Valid
+                        } else {
+                            OutputStatus::Invalid
+                        };
+
+                        let tx_failure =
+                            supported_bit_is_set(support[2], 0, tx_lane_flags[0], lane);
+                        let tx_los = supported_bit_is_set(support[2], 1, tx_lane_flags[1], lane);
+                        let tx_lol = supported_bit_is_set(support[2], 2, tx_lane_flags[2], lane);
+                        let tx_adaptive_eq_fail =
+                            supported_bit_is_set(support[2], 3, tx_lane_flags[3], lane);
+                        let rx_los = supported_bit_is_set(support[3], 1, rx_lane_flags[0], lane);
+
+                        // The datapath state is stored in a nibble within the
+                        // bytes read in `datapath_state`. The lower-order
+                        // nibble (bits 0-3) are the first of these two lanes,
+                        // the higher-order nibble (bits 4-7) are the second /
+                        // larger of the two lanes.
+                        //
+                        // See CMIS table 8-73 for details.
+                        let index = usize::from(lane / 2);
+                        let shift = if lane % 2 == 1 { 0 } else { 4 };
+                        let nibble = (datapath_state[index] & (0x0f << shift)) >> shift;
+                        let state = CmisDatapathState::try_from(nibble)?;
+                        let rx_lol = supported_bit_is_set(support[3], 2, rx_lane_flags[1], lane);
+
+                        let st = LaneStatus {
+                            state,
+                            tx_input_polarity,
+                            tx_output_enabled,
+                            tx_auto_squelch_disable,
+                            tx_force_squelch,
+                            rx_output_polarity,
+                            rx_output_enabled,
+                            rx_auto_squelch_disable,
+                            rx_output_status,
+                            tx_output_status,
+                            tx_failure,
+                            tx_los,
+                            tx_lol,
+                            tx_adaptive_eq_fail,
+                            rx_los,
+                            rx_lol,
+                        };
+
+                        // Add this lane, either to a new application keyed by
+                        // its AppSel code, or an existing.
+                        datapaths
+                            .entry(app_sel)
+                            .or_insert_with(|| CmisDatapath {
+                                application: app,
+                                lane_status: BTreeMap::new(),
+                            })
+                            .lane_status
+                            .insert(1 + lane, st);
+                    }
+                }
+                Ok(Datapath::Cmis {
+                    datapaths,
+                    connector,
+                    supported_lanes,
+                })
+            }
+            _ => Err(Error::UnsupportedIdentifier(id)),
+        }
+    }
+}
+
+/// The datapath of an SFF-8636 module.
+///
+/// This describes the state of a single lane in an SFF module. It includes
+/// information about input and output signals, faults, and controls.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+pub struct Sff8636Datapath {
+    /// Software control of output transmitter.
+    pub tx_enabled: bool,
+
+    /// Host-side loss of signal flag.
+    ///
+    /// This is true if there is no detected electrical signal from the
+    /// host-side serdes.
+    pub tx_los: bool,
+
+    /// Media-side loss of signal flag.
+    ///
+    /// This is true if there is no detected input signal from the media-side
+    /// (usually optical).
+    pub rx_los: bool,
+
+    /// Flag indicating a fault in adaptive transmit equalization.
+    pub tx_adaptive_eq_fault: bool,
+
+    /// Flag indicating a fault in the transmitter and/or laser.
+    pub tx_fault: bool,
+
+    /// Host-side loss of lock flag.
+    ///
+    /// This is true if the module is not able to extract a clock signal from
+    /// the host-side electrical signal.
+    pub tx_lol: bool,
+
+    /// Media-side loss of lock flag.
+    ///
+    /// This is true if the module is not able to extract a clock signal from
+    /// the media-side signal (usually optical).
+    pub rx_lol: bool,
+
+    /// Host-side transmit Clock and Data Recovery (CDR) enable status.
+    ///
+    /// CDR is the process by which the module enages an internal retimer
+    /// function, through which the module attempts to recovery a clock signal
+    /// directly from the input bitstream.
+    pub tx_cdr_enabled: bool,
+
+    /// Media-side transmit Clock and Data Recovery (CDR) enable status.
+    ///
+    /// CDR is the process by which the module enages an internal retimer
+    /// function, through which the module attempts to recovery a clock signal
+    /// directly from the input bitstream.
+    pub rx_cdr_enabled: bool,
+}
+
+/// A datapath in a CMIS module.
+///
+/// In contrast to SFF-8636, CMIS makes first-class the concept of a datpath: a
+/// set of lanes and all the associated machinery involved in the transfer of
+/// data. This includes:
+///
+/// - The "application descriptor" which is the host and media interfaces, and
+///   the lanes on each side used to transfer data;
+/// - The state of the datapath in a well-defined finite state machine (see CMIS
+///   5.0 section 6.3.3);
+/// - The flags indicating how the datapath components are operating, such as
+///   receiving an input Rx signal or whether the transmitter is disabled.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+pub struct CmisDatapath {
+    /// The application descriptor for this datapath.
+    pub application: ApplicationDescriptor,
+
+    /// The status bits for each lane in the datapath.
+    pub lane_status: BTreeMap<u8, LaneStatus>,
+}
+
+/// The status of a single CMIS lane.
+///
+/// If any particular control or status value is unsupported by a module, it is
+/// `None`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+pub struct LaneStatus {
+    /// The datapath state of this lane.
+    ///
+    /// See CMIS 5.0 section 8.9.1 for details.
+    pub state: CmisDatapathState,
+
+    /// The Tx input polarity.
+    ///
+    /// This indicates a host-side control that flips the polarity of the
+    /// host-side input signal.
+    pub tx_input_polarity: Option<Polarity>,
+
+    /// Whether the Tx output is enabled.
+    pub tx_output_enabled: Option<bool>,
+
+    /// Whether the host-side has disabled the Tx auto-squelch.
+    ///
+    /// The module can implement automatic squelching of the Tx output, if the
+    /// host-side input signal isn't valid. This indicates whether the host has
+    /// disabled such a setting.
+    pub tx_auto_squelch_disable: Option<bool>,
+
+    /// Whether the host-side has force-squelched the Tx output.
+    ///
+    /// This indicates that the host can _force_ squelching the output if the
+    /// signal is not valid.
+    pub tx_force_squelch: Option<bool>,
+
+    /// The Rx output polarity.
+    ///
+    /// This indicates a host-side control that flips the polarity of the
+    /// host-side output signal.
+    pub rx_output_polarity: Option<Polarity>,
+
+    /// Whether the Rx output is enabled.
+    ///
+    /// The host may control this to disable the electrical output from the
+    /// module to the host.
+    pub rx_output_enabled: Option<bool>,
+
+    /// Whether the host-side has disabled the Rx auto-squelch.
+    ///
+    /// The module can implement automatic squelching of the Rx output, if the
+    /// media-side input signal isn't valid. This indicates whether the host has
+    /// disabled such a setting.
+    pub rx_auto_squelch_disable: Option<bool>,
+
+    /// Status of host-side Rx output.
+    ///
+    /// This indicates whether the Rx output is sending a valid signal to the
+    /// host. Note that this is `Invalid` if the output is either muted (such as
+    /// squelched) or explicitly disabled.
+    pub rx_output_status: OutputStatus,
+
+    /// Status of media-side Tx output.
+    ///
+    /// This indicates whether the Rx output is sending a valid signal to the
+    /// media itself. Note that this is `Invalid` if the output is either muted
+    /// (such as squelched) or explicitly disabled.
+    pub tx_output_status: OutputStatus,
+
+    /// General Tx failure flag.
+    ///
+    /// This indicates that an internal and unspecified malfunction has occurred
+    /// on the Tx lane.
+    pub tx_failure: Option<bool>,
+
+    /// Host-side loss of signal flag.
+    ///
+    /// This is true if there is no detected electrical signal from the
+    /// host-side serdes.
+    pub tx_los: Option<bool>,
+
+    /// Host-side loss of lock flag.
+    ///
+    /// This is true if the module is not able to extract a clock signal from
+    /// the host-side electrical signal.
+    pub tx_lol: Option<bool>,
+
+    /// A failure in the Tx adaptive input equalization.
+    pub tx_adaptive_eq_fail: Option<bool>,
+
+    /// Media-side loss of signal flag.
+    ///
+    /// This is true if there is no detected input signal from the media-side
+    /// (usually optical).
+    pub rx_los: Option<bool>,
+
+    /// Media-side loss of lock flag.
+    ///
+    /// This is true if the module is not able to extract a clock signal from
+    /// the media-side signal (usually optical).
+    pub rx_lol: Option<bool>,
+}
+
+crate::bitfield_enum! {
+    name = CmisDatapathState,
+    description = "The state of a datapath in the CMIS datapath state machine.",
+    bits = 2:0,
+    variants = {
+        0x1, Deactivated, "Deactivated",
+        0x2, Init, "Initializing",
+        0x3, Deinit, "Deinitializing",
+        0x4, Activated, "Activated",
+        0x5, TxTurnOn, "Tx turning on",
+        0x6, TxTurnOff, "Tx turning off",
+        0x7, Initialized, "Initialized",
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+#[cfg_attr(any(feature = "api-traits", test), serde(rename_all = "snake_case"))]
+pub enum OutputStatus {
+    Valid,
+    Invalid,
+}
+
+impl fmt::Display for OutputStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputStatus::Valid => write!(f, "Valid"),
+            OutputStatus::Invalid => write!(f, "Invalid"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+#[cfg_attr(any(feature = "api-traits", test), serde(rename_all = "snake_case"))]
+pub enum Polarity {
+    Normal,
+    Flipped,
+}
+
+impl fmt::Display for Polarity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Polarity::Normal => write!(f, "Normal"),
+            Polarity::Flipped => write!(f, "Flipped"),
+        }
+    }
+}
+
+/// An Application Descriptor describes the supported datapath configurations.
+///
+/// This is a CMIS-specific concept. It's used for modules to advertise how it
+/// can be used by the host. Each application describes the host-side electrical
+/// interface; the media-side interface; the number of lanes required; etc.
+///
+/// Host-side software can select one of these applications to instruct the
+/// module to use a specific set of lanes, with the interface on either side of
+/// the module.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+pub struct ApplicationDescriptor {
+    /// The electrical interface with the host side.
+    pub host_id: HostElectricalInterfaceId,
+    /// The interface, optical or copper, with the media side.
+    pub media_id: MediaInterfaceId,
+    /// The number of host-side lanes.
+    pub host_lane_count: u8,
+    /// The number of media-side lanes.
+    pub media_lane_count: u8,
+    /// The lanes on the host-side supporting this application.
+    ///
+    /// This is a bit mask with a 1 identifying the lowest lane in a consecutive
+    /// group of lanes to which the application can be assigned. This must be
+    /// used with the `host_lane_count`. For example a value of `0b0000_0001`
+    /// with a host lane count of 4 indicates that the first 4 lanes may be used
+    /// in this application.
+    ///
+    /// An application may support starting from multiple lanes.
+    pub host_lane_assignment_options: u8,
+
+    /// The lanes on the media-side supporting this application.
+    ///
+    /// See `host_lane_assignment_options` for details.
+    pub media_lane_assignment_options: u8,
+}
+
+impl ApplicationDescriptor {
+    fn from_bytes(
+        media_type: MediaType,
+        bytes: [u8; 4],
+        media_lane_assignment_options: u8,
+    ) -> Option<Self> {
+        let host_id = HostElectricalInterfaceId::from(bytes[0]);
+        let media_id = MediaInterfaceId::from_u8(media_type, bytes[1])?;
+        let host_lane_count = (bytes[2] & 0xf0) >> 4;
+        let media_lane_count = bytes[2] & 0x0f;
+        let host_lane_assignment_options = bytes[3];
+        Some(Self {
+            host_id,
+            media_id,
+            host_lane_count,
+            media_lane_count,
+            host_lane_assignment_options,
+            media_lane_assignment_options,
+        })
+    }
+}
+
+/// Describes the application to which a specific lane is assigned.
+///
+/// This identifies which `ApplicationDescriptor`, if any, a lane belongs to,
+/// which describes the entire configuration of a datapath.
+///
+/// See CMIS 5.0 Table 8-82.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+pub struct LaneDatapathConfig {
+    /// The code (index) of the active Application Descriptor.
+    pub app_select_code: u8,
+    /// The index of the first lane in the data path containing this lane.
+    pub data_path_id: u8,
+    /// If true, the SI settings for this lane are controlled by the host.
+    ///
+    /// Otherwise, the module controls settings autonomously based on the
+    /// application.
+    pub explicit_control: bool,
+}
+
+impl LaneDatapathConfig {
+    /// Return `true` if this is lane is assigned to a datapath.
+    pub const fn is_assigned(&self) -> bool {
+        self.app_select_code != 0
+    }
+}
+
+impl From<u8> for LaneDatapathConfig {
+    fn from(x: u8) -> Self {
+        Self {
+            app_select_code: (x & 0xf0) >> 4,
+            data_path_id: (x & 0b1110) >> 1,
+            explicit_control: (x & 0b1) != 0,
+        }
+    }
+}
+
+impl From<&u8> for LaneDatapathConfig {
+    fn from(x: &u8) -> Self {
+        Self::from(*x)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ApplicationDescriptor;
+    use super::Datapath;
+    use super::HostElectricalInterfaceId;
+    use super::Identifier;
+    use super::MediaInterfaceId;
+    use super::MediaType;
+    use super::ParseFromModule;
+    use super::Sff8636Datapath;
+    use crate::ident::SmfMediaInterfaceId;
+    use crate::ConnectorType;
+    use crate::ExtendedSpecificationComplianceCode;
+    use crate::LaneDatapathConfig;
+    use crate::SffComplianceCode;
+
+    #[test]
+    fn test_decode_cmis_lane_datapath_config() {
+        // Lane is part of application descriptor with AppSel code 0b0110 == 6
+        // The first lane in the datapath containing this lane is 0b010 == 2
+        // This lane is explicitly host-controllable.
+        const BYTE: u8 = 0b0110 << 4 | 0b010 << 1 | 0b1;
+        let decoded = LaneDatapathConfig::from(BYTE);
+        assert_eq!(decoded.app_select_code, 6);
+        assert_eq!(decoded.data_path_id, 2);
+        assert!(decoded.explicit_control);
+    }
+
+    #[test]
+    fn test_application_descriptor_from_bytes() {
+        let media_type = MediaType::SingleModeFiber;
+        let host_id = HostElectricalInterfaceId::IdCaui4;
+        let media_id = MediaInterfaceId::Smf(SmfMediaInterfaceId::Id100GBaseLr4);
+        let n_lanes = 4;
+        let media_lane_assignment_options = 0b1;
+        let expected = ApplicationDescriptor {
+            host_id,
+            media_id,
+            host_lane_count: n_lanes,
+            media_lane_count: n_lanes,
+            host_lane_assignment_options: 0b1,
+            media_lane_assignment_options,
+        };
+        let bytes = [0x0b, 0x0d, (n_lanes << 4) | n_lanes, 0b1];
+        let app =
+            ApplicationDescriptor::from_bytes(media_type, bytes, media_lane_assignment_options)
+                .unwrap();
+        assert_eq!(app, expected);
+    }
+
+    #[test]
+    fn test_parse_sff8636_datapath() {
+        let expected = Datapath::Sff8636 {
+            connector: ConnectorType::LucentConnector,
+            lanes: [Sff8636Datapath {
+                tx_enabled: true,
+                tx_los: false,
+                rx_los: false,
+                tx_adaptive_eq_fault: false,
+                tx_fault: false,
+                tx_lol: true,
+                rx_lol: true,
+                tx_cdr_enabled: true,
+                rx_cdr_enabled: true,
+            }; 4],
+            specification: SffComplianceCode::Extended(
+                ExtendedSpecificationComplianceCode::Id100GBCwdm4,
+            ),
+        };
+        let bytes = [
+            // Tx-enable: all 4 lanes enabled
+            vec![0b0000],
+            // LOS: No LOS, no faults, yes LOL
+            vec![0b0000_0000, 0b0000_0000, 0b1111_1111],
+            // CDR: All channels have CDR on
+            vec![0b1111_1111],
+            // Connector type: LC
+            // Compliance: Extended
+            vec![0x07, 0x80],
+            // Extended compliance: 100G CWDM4
+            vec![0x06],
+        ];
+        let parsed = Datapath::parse(
+            Identifier::QsfpPlusSff8636,
+            bytes.iter().map(|s| s.as_slice()),
+        )
+        .unwrap();
+        assert_eq!(parsed, expected);
+    }
+}

--- a/decode/src/ident.rs
+++ b/decode/src/ident.rs
@@ -15,53 +15,51 @@ use transceiver_messages::mgmt::sff8636;
 pub use transceiver_messages::mgmt::ManagementInterface;
 use transceiver_messages::mgmt::MemoryRead;
 
-/// The SFF-8024 identifier for a transceiver module.
-///
-/// This identifier is used as the main description of the kind of module, and
-/// indicates the spec that the it should conform to. It is required to
-/// interpret the remainder of the memory map.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
-#[repr(u8)]
-#[cfg_attr(
-    any(feature = "api-traits", test),
-    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
-)]
-#[cfg_attr(any(feature = "api-traits", test), serde(rename_all = "snake_case"))]
-pub enum Identifier {
-    Unknown,
-    Gbic,
-    Soldered,
-    Sfp,
-    Xbi,
-    Xenpak,
-    Xfp,
-    Xff,
-    XffE,
-    Xpak,
-    X2,
-    DwdmSfp,
-    Qsfp,
-    QsfpPlusSff8636,
-    Cxp,
-    ShieldedMultiLane4,
-    ShieldedMultiLane8,
-    Qsfp28,
-    Cxp2,
-    Cdfp,
-    ShieldedMultiLane4Fanout,
-    ShieldedMultiLane8Fanout,
-    Cdfp3,
-    MicroQsfp,
-    QsfpDD,
-    Qsfp8,
-    SfpDD,
-    Dsfp,
-    X4MultiLink,
-    X8MiniLink,
-    QsfpPlusCmis,
-    Unsupported(u8),
-    Reserved(u8),
-    VendorSpecific(u8),
+crate::bitfield_enum! {
+    name = Identifier,
+    description = "The SFF-8024 Identifier for a transceiver module.\
+    \
+    This identifier is used as the main description of the kind of moduel, and
+    indicates the spec that it should conform to. It is requried to interpret
+    the remainder of the memory map.",
+    variants = {
+        0x00, Unknown, "Unknown or unspecified",
+        0x01, Gbic, "GBIC",
+        0x02, Soldered, "Module/connector soldered to motherboard",
+        0x03, Sfp, "SFP/SFP+/SFP28",
+        0x04, Xbi, "XBI",
+        0x05, Xenpak, "XENPAK",
+        0x06, Xfp, "XFP",
+        0x07, Xff, "XFF",
+        0x08, XffE, "XFP-E",
+        0x09, Xpak, "XPAK",
+        0x0a, X2, "X2",
+        0x0b, DwdmSfp, "DWDM-SFP/SFP+",
+        0x0c, Qsfp, "QSFP",
+        0x0d, QsfpPlusSff8636, "QSFP+ or later with SFF-8636 management interface",
+        0x0e, Cxp, "CXP or later",
+        0x0f, ShieldedMultiLane4, "Shielded mini multi-lane 4X",
+        0x10, ShieldedMultiLane8, "Shielded mini multi-lane 8X",
+        0x11, Qsfp28, "QSFP28 or later with SFF-8636 management interface",
+        0x12, Cxp2, "CXP2",
+        0x13, Cdfp, "CDFP (Style 1 or 2)",
+        0x14, ShieldedMultiLane4Fanout, "Shielded mini multi-lane 4X fanout",
+        0x15, ShieldedMultiLane8Fanout, "Shielded mini multi-lane 8X fanout",
+        0x16, Cdfp3, "CDFP (Style 3)",
+        0x17, MicroQsfp, "MicroQSFP",
+        0x18, QsfpDD, "QSFP-DD Double Density 8X Pluggable Transceiver",
+        0x19, Qsfp8, "QSFP 8X Pluggable Transceiver",
+        0x1a, SfpDD, "SFP-DD 2X Double Density Pluggable Transceiver",
+        0x1b, Dsfp, "DSFP Dual Small Form Factor Pluggable Transceiver",
+        0x1c, X4MultiLink, "x4 MiniLink/OcuLink",
+        0x1d, X8MiniLink, "x8 MiniLink",
+        0x1e, QsfpPlusCmis, "QSFP+ or later with Common Management Interface Specification",
+    },
+    other_variants = {
+        Reserved : 0x21..=0x7f,
+        VendorSpecific : 0x80..,
+        Unsupported : _,
+    }
 }
 
 impl Identifier {
@@ -72,134 +70,6 @@ impl Identifier {
             QsfpPlusCmis | QsfpDD => Ok(ManagementInterface::Cmis),
             _ => Err(Error::UnsupportedIdentifier(*self)),
         }
-    }
-}
-
-impl From<u8> for Identifier {
-    fn from(x: u8) -> Self {
-        use Identifier::*;
-        match x {
-            0x00 => Unknown,
-            0x01 => Gbic,
-            0x02 => Soldered,
-            0x03 => Sfp,
-            0x04 => Xbi,
-            0x05 => Xenpak,
-            0x06 => Xfp,
-            0x07 => Xff,
-            0x08 => XffE,
-            0x09 => Xpak,
-            0x0a => X2,
-            0x0b => DwdmSfp,
-            0x0c => Qsfp,
-            0x0d => QsfpPlusSff8636,
-            0x0e => Cxp,
-            0x0f => ShieldedMultiLane4,
-            0x10 => ShieldedMultiLane8,
-            0x11 => Qsfp28,
-            0x12 => Cxp2,
-            0x13 => Cdfp,
-            0x14 => ShieldedMultiLane4Fanout,
-            0x15 => ShieldedMultiLane8Fanout,
-            0x16 => Cdfp3,
-            0x17 => MicroQsfp,
-            0x18 => QsfpDD,
-            0x19 => Qsfp8,
-            0x1a => SfpDD,
-            0x1b => Dsfp,
-            0x1c => X4MultiLink,
-            0x1d => X8MiniLink,
-            0x1e => QsfpPlusCmis,
-            0x21..=0x7f => Reserved(x),
-            0x80.. => VendorSpecific(x),
-            _ => Unsupported(x),
-        }
-    }
-}
-
-impl From<Identifier> for u8 {
-    fn from(id: Identifier) -> Self {
-        use Identifier::*;
-        match id {
-            Unknown => 0x00,
-            Gbic => 0x01,
-            Soldered => 0x02,
-            Sfp => 0x03,
-            Xbi => 0x04,
-            Xenpak => 0x05,
-            Xfp => 0x06,
-            Xff => 0x07,
-            XffE => 0x08,
-            Xpak => 0x09,
-            X2 => 0x0a,
-            DwdmSfp => 0x0b,
-            Qsfp => 0x0c,
-            QsfpPlusSff8636 => 0x0d,
-            Cxp => 0x0e,
-            ShieldedMultiLane4 => 0x0f,
-            ShieldedMultiLane8 => 0x10,
-            Qsfp28 => 0x11,
-            Cxp2 => 0x12,
-            Cdfp => 0x13,
-            ShieldedMultiLane4Fanout => 0x14,
-            ShieldedMultiLane8Fanout => 0x15,
-            Cdfp3 => 0x16,
-            MicroQsfp => 0x17,
-            QsfpDD => 0x18,
-            Qsfp8 => 0x19,
-            SfpDD => 0x1a,
-            Dsfp => 0x1b,
-            X4MultiLink => 0x1c,
-            X8MiniLink => 0x1d,
-            QsfpPlusCmis => 0x1e,
-            Reserved(x) | VendorSpecific(x) | Unsupported(x) => x,
-        }
-    }
-}
-
-impl core::fmt::Display for Identifier {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        use Identifier::*;
-        write!(
-            f,
-            "{}",
-            match self {
-                Unknown => "Unknown or unspecified",
-                Gbic => "GBIC",
-                Soldered => "Module/connector soldered to motherboard",
-                Sfp => "SFP/SFP+/SFP28",
-                Xbi => "XBI",
-                Xenpak => "XENPAK",
-                Xfp => "XFP",
-                Xff => "XFF",
-                XffE => "XFP-E",
-                Xpak => "XPAK",
-                X2 => "X2",
-                DwdmSfp => "DWDM-SFP/SFP+",
-                Qsfp => "QSFP",
-                QsfpPlusSff8636 => "QSFP+ or later with SFF-8636 management interface",
-                Cxp => "CXP or later",
-                ShieldedMultiLane4 => "Shielded mini multi-lane 4X",
-                ShieldedMultiLane8 => "Shielded mini multi-lane 8X",
-                Qsfp28 => "QSFP28 or later with SFF-8636 management interface",
-                Cxp2 => "CXP2",
-                Cdfp => "CDFP (Style 1 or 2)",
-                ShieldedMultiLane4Fanout => "Shielded mini multi-lane 4X fanout",
-                ShieldedMultiLane8Fanout => "Shielded mini multi-lane 8X fanout",
-                Cdfp3 => "CDFP (Style 3)",
-                MicroQsfp => "MicroQSFP",
-                QsfpDD => "QSFP-DD Double Density 8X Pluggable Transceiver",
-                Qsfp8 => "QSFP 8X Pluggable Transceiver",
-                SfpDD => "SFP-DD 2X Double Density Pluggable Transceiver",
-                Dsfp => "DSFP Dual Small Form Factor Pluggable Transceiver",
-                X4MultiLink => "x4 MiniLink/OcuLink",
-                X8MiniLink => "x8 MiniLink",
-                QsfpPlusCmis => "QSFP+ or later with Common Management Interface Specification",
-                Reserved(_) => "Reserved",
-                VendorSpecific(_) => "Vendor Specific",
-                Unsupported(_) => "Unsupported",
-            }
-        )
     }
 }
 
@@ -437,6 +307,352 @@ fn ascii_to_string(buf: &[u8]) -> String {
                 .to_string()
         }
     }
+}
+
+crate::bitfield_enum! {
+    name = ExtendedSpecificationComplianceCode,
+    description = "Extended electrical or optical interface codes",
+    variants = {
+        0x00, Unspecified, "Unspecified",
+        0x01, Id100GAoc5en5, "100G AOC, retimed or 25GAUI C2M AOC (BER <= 5e-5)",
+        0x02, Id100GBaseSr4, "100GBASE-SR4 or 25GBASE-SR",
+        0x03, Id100GBaseLr4, "100GBASE-LR4 or 25GBASE-LR",
+        0x04, Id100GBaseEr4, "100GBASE-ER4 or 25GBASE-ER",
+        0x05, Id100GBaseSr10, "100GBASE-SR10",
+        0x06, Id100GBCwdm4, "100G CWDM4",
+        0x07, Id100GPsm4, "100G PSM4 Parallel SMF",
+        0x08, Id100GAcc, "100G ACC, retimed or 25GAUI C2M ACC",
+        0x09, Obsolete, "Obsolete",
+        0x0b, Id100GBaseCr4, "100GBASE-CR4, 25GBASE-CR CA-25G-L or 50GBASE-CR2 with RS FEC",
+        0x0c, Id25GBaseCrS, "25GBASE-CR CA-25G-S or 50GBASE-CR2 with BASE-R FEC",
+        0x0d, Id25GBaseCrN, "25GBASE-CR CA-25G-N or 50GBASE-CR2 with no FEC",
+        0x0e, Id10MbEth, "10 Mb/s Single Pair Ethernet",
+        0x10, Id40GBaseEr4, "40GBASE-ER4",
+        0x11, Id4x10GBaseSr, "4x10GBASE-SR",
+        0x12, Id40GPsm4, "40G PSM4 Parallel SMF",
+        0x13, IdG959p1i12d1, "G959.1 profile P1I1-2D1",
+        0x14, IdG959p1s12d2, "G959.1 profile P1S1-2D2",
+        0x15, IdG9592p1l1d1, "G959.1 profile P1L1-2D2",
+        0x16, Id10GBaseT, "10GBASE-T with SFI elecrical interface",
+        0x17, Id100GClr4, "100G CLR4",
+        0x18, Id100GAoc10en12, "100G AOC, retimed or 25GAUI C2M AOC (BER <= 10e-12)",
+        0x19, Id100GAcc10en12, "100G ACC, retimed or 25GAUI C2M ACC (BER <= 10e-12)",
+        0x1a, Id100GeDwdm2, "100GE-DWDM2",
+        0x1b, Id100GWdm, "100G 1550nm WDM",
+        0x1c, Id10GBaseTSr, "10GBASE-T Short Reach",
+        0x1d, Id5GBaseT, "5GBASE-T",
+        0x1e, Id2p5GBaseT, "2.5GBASE-T",
+        0x1f, Id40GSwdm4, "40G SWDM4",
+        0x20, Id100GSwdm4, "100G SWDM4",
+        0x21, Id100GPam4BiDi, "100G PAM4 BiDi",
+        0x37, Id10GBaseBr, "10GBASE-BR",
+        0x38, Id25GBaseBr, "25GBASE-BR",
+        0x39, Id50GBaseBr, "50GBASE-BR",
+        0x22, Id4wdm10, "4WDM-10 MSA",
+        0x23, Id4wdm20, "4WDM-20 MSA",
+        0x24, Id4wdm40, "4WDM-40 MSA",
+        0x25, Id100GBaseDr, "100GBASE-DR",
+        0x26, Id100GFr, "100G-FR or 100GBASE-FR1, CAUI-4",
+        0x27, Id100GLr, "100G-LR or 100GBASE-LR1, CAUI-4",
+        0x28, Id100GBaseSr1, "100GBASE-SR1, CAUI-4",
+        0x3a, Id100GBaseVr1, "100GBASE-VR1, CAUI-4",
+        0x29, Id100GBaseSr12, "100GBASE-SR1, 200GBASE-SR2 or 400GBASE-SR4",
+        0x36, Id100GBaseVr12, "100GBASE-VR1, 200GBASE-VR2 or 400GBASE-VR4",
+        0x2a, Id100GBaseFr1, "100GBASE-FR1",
+        0x2b, Id100GBaseLr1, "100GBASE-LR1",
+        0x2c, Id100GLr120Caui4, "100G-LR1-20 MSA, CAUI-4",
+        0x2d, Id100GLr130Caui4, "100G-LR1-30 MSA, CAUI-4",
+        0x2e, Id100GLr140Caui4, "100G-LR1-40 MSA, CAUI-4",
+        0x2f, Id100GLr120, "100G-LR1-20 MSA",
+        0x34, Id100GLr130, "100G-LR1-30 MSA",
+        0x35, Id100GLr140, "100G-LR1-40 MSA",
+        0x30, IdAcc50GAUI10en6, "Active Copper Cable with 50GAUI, 200GAUI-2 or 200GAUI-4 C2M (BER <= 10e-6)",
+        0x31, IdAcc50GAUI10en62, "Active Copper Cable with 50GAUI, 200GAUI-2 or 200GAUI-4 C2M (BER <= 10e-6)",
+        0x32, IdAcc50GAUI2p6en4, "Active Copper Cable with 50GAUI, 200GAUI-2 or 200GAUI-4 C2M (BER <= 2.6e-4 or 10e-5)",
+        0x33, IdAcc50GAUI2p6en41, "Active Copper Cable with 50GAUI, 200GAUI-2 or 200GAUI-4 C2M (BER <= 2.6e-4 or 10e-5)",
+        0x3f, Id100GBaseCr1, "100GBASE-CR1, 200GBASE-CR2 or 400GBASE-CR4",
+        0x40, Id50GBaseCr, "50GBASE-CR, 100GBASE-CR2 or 200GBASE-CR4",
+        0x41, Id50GBaseSr, "50GBASE-SR, 100GBASE-SR2 or 200GBASE-SR4",
+        0x42, Id50GBaseFr, "50GBASE-FR or 200GBASE-DR4",
+        0x4a, Id50GBaseEr, "50GBASE-ER",
+        0x43, Id200GBaseFr4, "200GBASE-FR4",
+        0x44, Id200GPsm4, "200G 1550nm PSM4",
+        0x45, Id50GBaseLr, "50GBASE-LR",
+        0x46, Id200GBaseLr4, "200GBASE-LR4",
+        0x47, Id400GBaseDr4, "400GBASE-DR4",
+        0x48, Id400GBaseFr4, "400GBASE-FR4",
+        0x49, Id400GBaseLr4, "400GBASE-LR4-6",
+        0x4b, Id400GGLr410, "400G-LR4-10",
+        0x4c, Id400GBaseZr, "400GBASE-ZR",
+        0x7f, Id256GfcSw4, "256GFC-SW4",
+        0x80, Id64Gfc, "64GFC",
+        0x81, Id128Gfc, "128GFC",
+    },
+    other_variants = { Reserved : 0x0a | 0x0f | 0x3b..=0x3e | 0x4d..=0x7e | 0x82..=0xff },
+}
+
+crate::bitfield_enum! {
+    name = HostElectricalInterfaceId,
+    description = "The host electrical interface ID.\
+    \
+    See SFF-8024, table 4-5.",
+    variants = {
+        0x00, Undefined, "Undefined",
+        0x01, Id1000BaseCX, "1000BASE-CX",
+        0x02, IdXaui, "XAUI",
+        0x03, IdXfi, "XFI",
+        0x04, IdSfi, "SFI",
+        0x05, Id25Gaui, "25GAUI C2M",
+        0x06, IdXlaui, "XLAUI C2M",
+        0x07, IdXlppi, "XLPPI",
+        0x08, IdXlaui2, "LAUI-2 C2M",
+        0x09, Id50Gaui2, "50GAUI-2 C2M",
+        0x0a, Id50Gaui1, "50GAUI-1 C2M",
+        0x0b, IdCaui4, "CAUI-4 C2M",
+        0x41, IdCaui4WithoutFec, "CAUI-4 C2M with out FEC",
+        0x42, IdCaui4WithRsFec, "CAUI-4 C2M with RS(528, 514) FEC",
+        0x0c, Id100GGaui4, "100GAUI-4 C2M",
+        0x0d, Id100GGaui2, "100GAUI-2 C2M",
+        0x4b, Id100GGaui1S, "100GAUI-1-S C2M",
+        0x4c, Id100GGaui1L, "100GAUI-1-L C2M",
+        0x0e, Id200GGaui8, "200GAUI-8 C2M",
+        0x0f, Id200GGaui4, "200GAUI-4 C2M",
+        0x4d, Id200GGaui2S, "200GAUI-2-S C2M",
+        0x4e, Id200GGaui2L, "200GAUI-2-L C2M",
+        0x10, Id400Gaui16, "400GAUI-16 C2M",
+        0x11, Id400Gaui8, "400GAUI-8 C2M",
+        0x4f, Id400Gaui4S, "400GAUI-4-S C2M",
+        0x50, Id400Gaui4L, "400GAUI-4-L C2M",
+        0x51, Id800GS, "800G S C2M",
+        0x52, Id800GL, "800G L C2M",
+        0x13, Id10GBaseCx4, "10GBASE-CX4",
+        0x14, Id25GBaseCrCa25GL, "25GBASE-CR CA-25G-L",
+        0x15, Id25GBaseCrS, "25GBASE-CR or 25GBASE-CR-S CA-25G-S",
+        0x16, Id25GBaseCrN, "25GBASE-CR or 25GBASE-CR-S CA-25G-N",
+        0x17, Id40GBaseCr4, "40GBASE-CR4",
+        0x43, Id50GBaseCr2WithRsFec, "50GBASE-CR2 with RS(528, 514) FEC",
+        0x44, Id50GBaseCr2WithFirecodeFec, "50GBASE-CR2 with Firecode FEC",
+        0x45, Id50GBaseCr2, "50GBASE-CR2 with no FEC",
+        0x18, Id50GBaseCr, "50GBASE-CR",
+        0x19, Id100GBaseCr10, "100GBASE-CR10",
+        0x1a, Id100GBaseCr4, "100GBASE-CR4",
+        0x1b, Id100GBaseCr2, "100GBASE-CR2",
+        0x46, Id100GBaseCr1, "100GBASE-CR1",
+        0x1c, Id200GBaseCr4, "200GBASE-CR4",
+        0x47, Id200GBaseCr2, "200GBASE-CR2",
+        0x1d, Id400GCr8, "400G CR8",
+        0x48, Id400GBaseCr4, "400GBASE-CR4",
+        0x49, Id800GEtcCr8, "800G-ETC-CR8",
+        0xff, EndOfList, "End of list",
+    },
+    other_variants = {
+        Reserved : 0x12 | 0x30..=0x36 | 0x54..=0xbf,
+        Custom : 0xce..=0xfe,
+        Other : _
+    },
+}
+
+crate::bitfield_enum! {
+    name = MediaType,
+    description = "The encoding type for a `MediaInterfaceId`.\
+    \
+    This is used to determine which SFF-8024 table can be used to decode a media\
+    interface type. This applies to both host- and media-side interfaces, and\
+    eletrical / optical.",
+    variants = {
+        0x00, Undefined, "Undefined",
+        0x01, MultiModeFiber, "Multi-mode fiber",
+        0x02, SingleModeFiber, "Single-mode fiber",
+        0x03, PassiveCopper, "Passive copper",
+        0x04, ActiveCable, "Active cable",
+        0x05, BaseT, "BASE-T",
+    },
+    other_variants = {
+        Custom : 0x40..=0x8f,
+        Reserved: _,
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    any(feature = "api-traits", test),
+    derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
+)]
+#[cfg_attr(any(feature = "api-traits", test), serde(rename_all = "snake_case"))]
+pub enum MediaInterfaceId {
+    Mmf(MmfMediaInterfaceId),
+    Smf(SmfMediaInterfaceId),
+    PassiveCopper(PassiveCopperMediaInterfaceId),
+    ActiveCable(ActiveCableMediaInterfaceId),
+    BaseT(BaseTMediaInterfaceId),
+}
+
+impl fmt::Display for MediaInterfaceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MediaInterfaceId::Mmf(inner) => write!(f, "{inner} (MMF)"),
+            MediaInterfaceId::Smf(inner) => write!(f, "{inner} (SMF)"),
+            MediaInterfaceId::PassiveCopper(inner) => write!(f, "{inner} (Passive copper)"),
+            MediaInterfaceId::ActiveCable(inner) => write!(f, "{inner} (Active cable)"),
+            MediaInterfaceId::BaseT(inner) => write!(f, "{inner} (BASE-T)"),
+        }
+    }
+}
+
+impl MediaInterfaceId {
+    pub fn from_u8(media_type: MediaType, x: u8) -> Option<Self> {
+        match media_type {
+            MediaType::Undefined | MediaType::Reserved(_) | MediaType::Custom(_) => None,
+            MediaType::MultiModeFiber => Some(MediaInterfaceId::Mmf(MmfMediaInterfaceId::from(x))),
+            MediaType::SingleModeFiber => Some(MediaInterfaceId::Smf(SmfMediaInterfaceId::from(x))),
+            MediaType::PassiveCopper => Some(MediaInterfaceId::PassiveCopper(
+                PassiveCopperMediaInterfaceId::from(x),
+            )),
+            MediaType::ActiveCable => Some(MediaInterfaceId::ActiveCable(
+                ActiveCableMediaInterfaceId::from(x),
+            )),
+            MediaType::BaseT => Some(MediaInterfaceId::BaseT(BaseTMediaInterfaceId::from(x))),
+        }
+    }
+}
+
+crate::bitfield_enum! {
+    name = MmfMediaInterfaceId,
+    description = "Media interface ID for multi-mode fiber media.\
+    \
+    See SFF-8024 Table 4-6.",
+    variants = {
+        0x00, Undefined, "Undefined",
+        0x01, Id10GBaseSw, "10GBASE-SW",
+        0x02, Id10GBaseSr, "10GBASE-SR",
+        0x03, Id25GBaseSr, "25GBASE-SR",
+        0x04, Id40GBaseSr3, "40GBASE-SR4",
+        0x05, Id40GESwdm4, "40GE SWDM4",
+        0x06, Id40GEBiDi, "40GE BiDi",
+        0x07, Id50GBaseSr, "50GBASE-SR",
+        0x08, Id100GBaseSr10, "100GBASE-SR10",
+        0x09, Id100GBaseSr4, "100GBASE-SR4",
+        0x0a, Id100GBaseSwdm4, "100GE SWDM4",
+        0x0b, Id100GEBiDi, "100GE BiDi",
+        0x0c, Id100GBaseSr2, "100GBASE-SR2",
+        0x0d, Id100GBaseSr1, "100GBASE-SR1",
+        0x1d, Id100GBaseVr1, "100GBASE-VR1",
+        0x0e, Id200GBaseSr4, "200GBASE-SR4",
+        0x1b, Id200GBaseSr2, "200GBASE-SR2",
+        0x1e, Id200GBaseVr2, "200GBASE-VR2",
+        0x0f, Id400GBaseSr16, "400GBASE-SR16",
+        0x10, Id400GBaseSr8, "400GBASE-SR8",
+        0x11, Id400GBaseSr4, "400GBASE-SR4",
+        0x1f, Id400GBaseVr4, "400GBASE-VR4",
+        0x12, Id800GBaseSr8, "800GBASE-SR8",
+        0x20, Id800GBaseVr8, "800GBASE-VR8",
+        0x1a, Id400GBaseSr42, "400GBASE-SR4.2",
+    },
+    other_variants = { Reserved : _, }
+}
+
+crate::bitfield_enum! {
+    name = SmfMediaInterfaceId,
+    description = "Media interface ID for single-mode fiber.\
+    \
+    See SFF-8024 Table 4-7.",
+    variants = {
+        0x00, Undefined, "Undefined",
+        0x01, Id10GBaseLw, "10GBASE-LW",
+        0x02, Id10GBaseEw, "10GBASE-EW",
+        0x03, Id10GZw, "10G-ZW",
+        0x04, Id10GBaseLr, "10GBASE-LR",
+        0x05, Id10GBaseEr, "10GBASE-ER",
+        0x4e, Id10GBaseBr, "10GBASE-BR",
+        0x06, Id10GZr, "10G-ZR",
+        0x07, Id25GBaseLr, "25GBASE-LR",
+        0x08, Id25GBaseEr, "25GBASE-ER",
+        0x4f, Id25GBaseBr, "25GBASE-BR",
+        0x09, Id40GBaseLr4, "40GBASE-LR4",
+        0x0a, Id40GBaseFr, "40GBASE-FR",
+        0x0b, Id50GBaseFr, "50GBASE-FR",
+        0x0c, Id50GBaseLr, "50GBASE-LR",
+        0x40, Id50GBaseEr, "50GBASE-ER",
+        0x50, Id50GBaseBr, "50GBASE-BR",
+        0x0d, Id100GBaseLr4, "100GBASE-LR4",
+        0x0e, Id100GBaseEr4, "100GBASE-ER4",
+        0x0f, Id100GPsm4, "100G PSM4",
+        0x34, Id100GCwdm4Ocp, "100G CWDM4-OCP",
+        0x10, Id100GCwdm4, "100G CWDM4",
+        0x11, Id100G4wdm10, "100G 4WDM-10",
+        0x12, Id100G4wdm20, "100G 4WDM-20",
+        0x13, Id100G4wdm40, "100G 4WDM-40",
+        0x14, Id100GBaseDr, "100GBASE-DR",
+        0x15, Id100GFr, "100G-FR / 100GBASE-FR1",
+        0x16, Id100GLr, "100G-LR / 100GBASE-LR1",
+        0x4a, Id100GLr120, "100G-LR1-20",
+        0x4b, Id100GEr130, "100G-ER1-30",
+        0x4c, Id100GEr140, "100G-ER1-40",
+        0x44, Id100GBaseZr, "100GBASE-ZR",
+        0x17, Id200GBaseDr4, "200GBASE-DR4",
+        0x18, Id200GBaseFr4, "200GBASE-FR4",
+        0x19, Id200GBaseLr4, "200GBASE-LR4",
+        0x41, Id200GBaseEr4, "200GBASE-ER4",
+        0x1a, Id400GBaseFr8, "400GBASE-FR8",
+        0x1b, Id400GBaseLr8, "400GBASE-LR8",
+        0x42, Id400GBaseEr8, "400GBASE-ER8",
+        0x1c, Id400GBaseDr4, "400GBASE-DR4",
+        0x55, Id400GBaseDr42, "400GBASE-DR4-2",
+        0x1d, Id400GFr4, "400G-FR4 / 400GBASE-FR4",
+        0x43, Id400GBaseLr46, "400GBASE-LR4-6",
+        0x1e, Id400GLr410, "400G-LR4-10",
+        0x4d, Id400GBaseZr, "400GBASE-ZR",
+        0x56, Id800GBaseDr8, "800GBASE-DR8",
+        0x57, Id800GBaseDr82, "800GBASE-DR8-2",
+    },
+    other_variants = { Reserved : _ },
+}
+
+crate::bitfield_enum! {
+    name = PassiveCopperMediaInterfaceId,
+    description = "Media interface ID for passive copper cables.\
+    \
+    See SFF-8024 Table 4-8.",
+    variants = {
+        0x00, Undefined, "Undefined",
+        0x01, CopperCable, "Copper cable",
+        0xbf, PassiveLoopback, "Passive loopback",
+    },
+    other_variants = { Custom : 0xc0..=0xff, Reserved : 0x02..=0xbf },
+}
+
+crate::bitfield_enum! {
+    name = ActiveCableMediaInterfaceId,
+    description = "Media interface ID for active cable assemblies.\
+    \
+    See SFF-8024 Table 4-9.",
+    variants = {
+        0x00, Undefined, "Undefined",
+        0x01, ActiveWithBer1en12, "Active Cable assembly with BER < 1e-12",
+        0x02, ActiveWithBer5en5, "Active Cable assembly with BER < 5e-5",
+        0x03, ActiveWithBer2p6en4, "Active Cable assembly with BER < 2.6e-4",
+        0x04, ActiveWithBer10en6, "Active Cable assembly with BER < 10e-6",
+        0xbf, ActiveLoopback, "Active loopback",
+    },
+    other_variants = { Reserved : 0x05..=0xbe, Custom : 0xc0..=0xff },
+}
+
+crate::bitfield_enum! {
+    name = BaseTMediaInterfaceId,
+    description = "Media interface ID for BASE-T.\
+    \
+    See SFF-8024 Table 4-10.",
+    variants = {
+        0x00, Undefined, "Undefined",
+        0x01, Id1000BaseT, "1000BASE-T",
+        0x02, Id2p5GBaseT, "2.5GBASE-T",
+        0x03, Id5GBaseT, "5GBASE-T",
+        0x04, Id10GBaseT, "10GBASE-T",
+        0x05, Id25GBaseT, "25GBASE-T",
+        0x06, Id40GBaseT, "40GBASE-T",
+        0x07, Id50GBaseT, "50GBASE-T",
+    },
+    other_variants = { Custom: 0xc0..=0xff, Reserved: 0x08..=0xbf },
 }
 
 #[cfg(test)]

--- a/decode/src/lib.rs
+++ b/decode/src/lib.rs
@@ -6,11 +6,14 @@
 
 //! Decode various transceiver module memory maps and data.
 
+mod datapath;
 mod ident;
 mod memory_model;
 mod monitors;
 mod power;
+mod utils;
 
+pub use datapath::*;
 pub use ident::*;
 pub use memory_model::*;
 pub use monitors::*;
@@ -34,6 +37,12 @@ pub enum Error {
 
     #[error("Invalid OUI")]
     InvalidOui,
+
+    #[error("Invalid bitfield pattern")]
+    InvalidBitField,
+
+    #[error("Bit out of range")]
+    BitOutOfRange,
 }
 
 /// A trait used to read and parse data from a transceiver memory map.

--- a/decode/src/utils.rs
+++ b/decode/src/utils.rs
@@ -224,7 +224,7 @@ mod tests {
             }
         }
 
-        for shift in 8.. {
+        for shift in 8..=255 {
             assert!(extract_bit(0, shift).is_err());
         }
     }

--- a/decode/src/utils.rs
+++ b/decode/src/utils.rs
@@ -1,0 +1,231 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! Utilities to make decoding various map data less terrible.
+
+use crate::Error;
+
+/// Extract a bit from a byte.
+pub const fn extract_bit(word: u8, bit: u8) -> Result<bool, Error> {
+    if bit > 7 {
+        return Err(Error::BitOutOfRange);
+    }
+    Ok((word & (1 << bit)) != 0)
+}
+
+mod private {
+    pub trait ScalableSealed: Sized + Copy + Into<f32> {}
+}
+
+pub trait Scalable: private::ScalableSealed {
+    fn from_bytes(buf: [u8; 2]) -> Self;
+}
+
+impl private::ScalableSealed for i16 {}
+
+impl Scalable for i16 {
+    fn from_bytes(buf: [u8; 2]) -> Self {
+        Self::from_be_bytes(buf)
+    }
+}
+
+impl private::ScalableSealed for u16 {}
+
+impl Scalable for u16 {
+    fn from_bytes(buf: [u8; 2]) -> Self {
+        Self::from_be_bytes(buf)
+    }
+}
+
+/// Decode a 2-byte word into a float with a defined scale factor.
+pub fn decode_with_scale<T: Scalable>(buf: [u8; 2], scale: f32) -> f32 {
+    T::from_bytes(buf).into() * scale
+}
+
+/// A helper macro to generate an enum from a bitfield.
+///
+/// Bitfields are common in the CMIS spec. These are often just a few bits, and
+/// are used to represent a set of distinct values, making it attractive to
+/// represent them in Rust with an enum. This macro can be used to generate an
+/// enum that maps a set of bits to enum variants.
+///
+/// It also generates a `TryFrom<u8>` implementation and a `Display`
+/// implementation.
+///
+/// # Example
+/// ```ignore
+/// /// Suppose we have a 2-bit pattern, that maps to some defined values.
+/// ///
+/// /// 0b00 -> First
+/// /// 0b01 -> Second
+/// /// 0b10 -> Third
+/// /// 0b11 -> Fourth
+/// ///
+/// /// And suppose this appears in bits [3:2] of a single byte. Then we can
+/// /// make an enum to represent this with:
+///
+/// transceiver_decode::utils::bitfield_enum! {
+///     Foo,
+///     "An bit pattern representing foo",
+///     3:2,
+///     0b00, First, "The first value",
+///     0b01, Second, "The second value",
+///     0b10, Third, "The third value",
+///     0b11, Fourth, "The fourth value",
+/// }
+/// ```
+#[macro_export]
+macro_rules! bitfield_enum {
+    (
+        name = $name:ident,
+        description = $docstring:literal,
+        variants = { $( $bits:literal, $variant:ident, $display:literal $(,)? ),+ },
+        other_variants = { $( $other_variant:ident : $other_pattern:pat $(,)? ),* }
+        $(,)?
+    ) => {
+        #[doc = $docstring]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[cfg_attr(
+            any(feature = "api-traits", test),
+            derive(schemars::JsonSchema, serde::Deserialize, serde::Serialize)
+        )]
+        #[cfg_attr(
+            any(feature = "api-traits", test),
+            serde(rename_all = "snake_case"),
+        )]
+        pub enum $name {
+            $($variant),+,
+            $($other_variant(u8)),+
+        }
+
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                use $name::*;
+                #[deny(overlapping_range_endpoints)]
+                match self {
+                    $( $variant => write!(f, "{}", $display), )+
+                    $( $other_variant(x) => write!(f, "{} ({x:02x})", stringify!($other_variant)), )+
+                }
+            }
+        }
+
+        impl ::core::convert::From<u8> for $name {
+            fn from(x: u8) -> Self {
+                use $name::*;
+                #[deny(overlapping_range_endpoints)]
+                match x {
+                    $( $bits => $variant, )+
+                    $( $other_pattern => $other_variant(x), )+
+                }
+            }
+        }
+
+        impl ::core::convert::From<$name> for u8 {
+            fn from(x: $name) -> u8 {
+                use $name::*;
+                #[deny(overlapping_range_endpoints)]
+                match x {
+                    $( $variant => $bits, )+
+                    $( $other_variant(x) => x, )+
+                }
+            }
+        }
+    };
+
+    (
+        name = $name:ident,
+        description = $docstring:literal,
+        bits = $high_bit:literal : $low_bit:literal,
+        variants = { $( $bits:literal, $variant:ident, $display:literal $(,)? ),+ }
+        $(,)?
+    ) => {
+        // Sanity checks on the bit ranges.
+        static_assertions::const_assert!($high_bit < 8);
+        static_assertions::const_assert!($low_bit < 8);
+        static_assertions::const_assert!($low_bit <= $high_bit);
+
+        // Sanity check that the bit patterns are all within the mask.
+        $( static_assertions::const_assert_eq!($name::MASK | $bits, $name::MASK); )+
+
+        // Sanity check that the mask is _equal_ to all the bit patterns OR'd
+        // together.
+        static_assertions::const_assert_eq!( $name::MASK, $( $bits )|+ );
+
+        impl $name {
+            #[allow(dead_code)]
+            pub const HIGH_BIT: u8 = $high_bit;
+            #[allow(dead_code)]
+            pub const LOW_BIT: u8 = $low_bit;
+            pub const MASK: u8 = (0xff << $low_bit) & (0xff >> (7 - $high_bit));
+        }
+
+        #[doc = $docstring]
+        #[derive(Clone, Copy, Debug, PartialEq)]
+        #[cfg_attr(
+            any(feature = "api-traits", test),
+            derive(schemars::JsonSchema, serde::Deserialize, serde::Serialize)
+        )]
+        pub enum $name {
+            $($variant),+
+        }
+
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                use $name::*;
+                #[deny(overlapping_range_endpoints)]
+                match self {
+                    $( $variant => write!(f, "{}", $display), )+
+                }
+            }
+        }
+
+        impl ::core::convert::TryFrom<u8> for $name {
+            type Error = Error;
+
+            fn try_from(x: u8) -> Result<Self, Self::Error> {
+                use $name::*;
+                #[deny(overlapping_range_endpoints)]
+                match (x & Self::MASK) >> $low_bit {
+                    $( $bits => Ok($variant), )+
+                    _ => Err(Error::InvalidBitField),
+                }
+            }
+        }
+
+        impl ::core::convert::From<$name> for u8 {
+            fn from(x: $name) -> u8 {
+                use $name::*;
+                #[deny(overlapping_range_endpoints)]
+                match x {
+                    $( $variant => $bits, )+
+                }
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_bit;
+
+    #[test]
+    fn test_extract_bit() {
+        for shift in 0..8 {
+            let expected = 1 << shift;
+            assert_eq!(extract_bit(expected, shift).unwrap(), true);
+            for other_shift in 0..8 {
+                if shift == other_shift {
+                    continue;
+                }
+                assert_eq!(extract_bit(expected, other_shift).unwrap(), false);
+            }
+        }
+
+        for shift in 8..=255 {
+            assert!(extract_bit(0, shift).is_err());
+        }
+    }
+}

--- a/decode/src/utils.rs
+++ b/decode/src/utils.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! Utilities to make decoding various map data less terrible.
 
@@ -224,7 +224,7 @@ mod tests {
             }
         }
 
-        for shift in 8..=255 {
+        for shift in 8.. {
             assert!(extract_bit(0, shift).is_err());
         }
     }

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
@@ -61,12 +61,12 @@
 //! the cause of the error in detail.
 //!
 //! > **Important**: In the case that _both_ success and error data is returned
-//! in a response, success data is serialized **first**, followed immediately by
-//! error data. The length of each can be computed with
-//! [`SpResponse::expected_data_len`](message::SpResponse::expected_data_len)
-//! and
-//! [`SpResponse::expected_error_data_len`](message::SpResponse::expected_error_data_len),
-//! respectively.
+//! > in a response, success data is serialized **first**, followed immediately by
+//! > error data. The length of each can be computed with
+//! > [`SpResponse::expected_data_len`](message::SpResponse::expected_data_len)
+//! > and
+//! > [`SpResponse::expected_error_data_len`](message::SpResponse::expected_error_data_len),
+//! > respectively.
 //!
 //! For the most part, `HostRequest` variants do not contain any trailing data.
 //! The exception is [`HostRequest::Write`](message::HostRequest::Write), which
@@ -75,9 +75,9 @@
 //! descriptor.
 //!
 //! > **Important**: The trailing data in a `HostRequest::Write` message is
-//! _broadcast_ to all modules indicate by the message. After a successful
-//! write, every module will contain the requested data in the memory map
-//! location indicated by the write descriptor.
+//! > _broadcast_ to all modules indicate by the message. After a successful
+//! > write, every module will contain the requested data in the memory map
+//! > location indicated by the write descriptor.
 //!
 //! # Full message format
 //!

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -2,10 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! Message formats and definitions.
-//!
 
 use crate::mac::BadMacAddrRange;
 use crate::mac::MacAddrs;

--- a/messages/src/mgmt/mod.rs
+++ b/messages/src/mgmt/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! Specifications for transceiver management interfaces.
 
@@ -129,12 +129,12 @@ pub enum ManagementInterface {
 /// client(s).
 ///
 /// > Important! It's the responsibility of the _host_ to determine if a given
-/// page or bank is supported by any particular module. We'd like to keep as
-/// much intelligence about parsing the memory maps in the host as possible,
-/// including identifying the management specification, and which pages if any
-/// are supported for a module. The intention is for the SP to only interpret
-/// sections of the map insofar as required for temperature and power
-/// monitoring.
+/// > page or bank is supported by any particular module. We'd like to keep as
+/// > much intelligence about parsing the memory maps in the host as possible,
+/// > including identifying the management specification, and which pages if any
+/// > are supported for a module. The intention is for the SP to only interpret
+/// > sections of the map insofar as required for temperature and power
+/// > monitoring.
 ///
 /// Note that modules generally don't _fail_ a memory access to an unsupported
 /// page. Instead, modules generally just revert the page- or bank-select bytes


### PR DESCRIPTION
- Add methods for decoding SFF-8636 datapath. This is relatively simple, mostly including a bunch of flags indicating whether transmitters are enabled, LOS / LOL alarms are asserted, and the like.
- Add some macros for creating an enum from a bitfield. This has a few flavors, but generally lets us automatically create an enum where some defined subset of the bits is mapped to a variant name and a string `Display` representation for it. This includes support for specifying exactly which bits are expected to be set, as well as one or more catchall variants. This is mostly used for defining the giant enums for decoding SFF-8024 codes like the host electrical interface ID.
- Adds new enums for the key bits we need from a datapath: `ConnectorType`, `HostElectricalInterfaceId`, `MediaType`, `MediaInterfaceId`, and the `ExtendedSpecificationCompliance` codes. These are the critical parts that define the physical path the data takes and how all the pieces (host, fixed-side, media-side, etc) all talk to one another.
- Add enums for media IDs broken out by media type, most notably MMF and SMF fiber types.
- Add methods for decoding the active CMIS datapath. We actually decode _all_ supported datapaths, but then only return the active ones. Note that I've tested most of the _pieces_ here, but the overall logic for extracting them is pretty complicated. It could use more tests, I'm sure.
- Add the `xcvradm datapath` subcommand, which decodes the datapaths for all the selected modules, broken out by their management interface.