### PR TITLE
Rename `LaneStatus` to `CmisLaneStatus`

### DIFF
--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -42,9 +42,9 @@ use transceiver_controller::VendorInfoResult;
 use transceiver_decode::Aux1Monitor;
 use transceiver_decode::Aux2Monitor;
 use transceiver_decode::Aux3Monitor;
+use transceiver_decode::CmisLaneStatus;
 use transceiver_decode::ConnectorType;
 use transceiver_decode::Datapath;
-use transceiver_decode::LaneStatus;
 use transceiver_decode::ReceiverPower;
 use transceiver_decode::Sff8636Datapath;
 use transceiver_decode::SffComplianceCode;
@@ -1477,7 +1477,7 @@ fn print_datapath(datapath: &DatapathResult) {
     }
 }
 
-type CmisLaneStatusPrinter = fn(&LaneStatus) -> String;
+type CmisLaneStatusPrinter = fn(&CmisLaneStatus) -> String;
 type CmisRowPrinter<'a> = (&'a str, CmisLaneStatusPrinter);
 
 fn print_cmis_datapath(

--- a/decode/src/datapath.rs
+++ b/decode/src/datapath.rs
@@ -580,7 +580,7 @@ impl ParseFromModule for Datapath {
                         let state = CmisDatapathState::try_from(nibble)?;
                         let rx_lol = supported_bit_is_set(support[3], 2, rx_lane_flags[1], lane);
 
-                        let st = LaneStatus {
+                        let st = CmisLaneStatus {
                             state,
                             tx_input_polarity,
                             tx_output_enabled,
@@ -702,7 +702,7 @@ pub struct CmisDatapath {
     pub application: ApplicationDescriptor,
 
     /// The status bits for each lane in the datapath.
-    pub lane_status: BTreeMap<u8, LaneStatus>,
+    pub lane_status: BTreeMap<u8, CmisLaneStatus>,
 }
 
 /// The status of a single CMIS lane.
@@ -714,7 +714,7 @@ pub struct CmisDatapath {
     any(feature = "api-traits", test),
     derive(serde::Deserialize, serde::Serialize, schemars::JsonSchema)
 )]
-pub struct LaneStatus {
+pub struct CmisLaneStatus {
     /// The datapath state of this lane.
     ///
     /// See CMIS 5.0 section 8.9.1 for details.


### PR DESCRIPTION
We're going to consume this in a downstream crate where there's already another type named `LaneStatus` in the API. This avoids the naming conflict, and is kind of helpful anyway to distinguish from an SFF-8636 datapath lane status.