### PR TITLE
Initial parsable output flags for xcvradm

### DIFF
--- a/controller/src/bin/xcvradm.rs
+++ b/controller/src/bin/xcvradm.rs
@@ -793,7 +793,7 @@ enum VendorInfoFields {
     Rev,
     /// Serial number of the transceiver module.
     Serial,
-    /// Manufactured date formatted as a date-code specified in SFF-8636
+    /// Manufactured date formatted as a date-code specified in SFF-8636.
     ManufacturedDate,
 }
 


### PR DESCRIPTION
This PR adds new flags to the "read" commands of `xcvradm`. The pattern is as followings:
* `-p` `--parsable` - Flag to toggle outputting in parsable format
* `-o` `--output` -  List of comma fields to output. Fields will be output in the order defined, with repeated values allowed.
* `--output-separator` - Separator used to delineate field values.

There is still no flag for omitting headers that needs to be added.

This PR should not change the default behavior of any commands.