### PR TITLE
messages: more robustly handle unknown HwError's from a peer

### DIFF
--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -11,6 +11,7 @@ use crate::ioloop::IoLoop;
 use crate::messages::*;
 use crate::results::*;
 use crate::Error;
+use crate::MaybeUnknown;
 use crate::PowerMode;
 use crate::PowerState;
 use crate::TransceiverError;
@@ -46,6 +47,7 @@ use transceiver_messages::merge_module_data;
 use transceiver_messages::message;
 use transceiver_messages::message::Header;
 use transceiver_messages::message::HostRequest;
+use transceiver_messages::message::HwError;
 pub use transceiver_messages::message::LedState;
 use transceiver_messages::message::MacAddrResponse;
 use transceiver_messages::message::Message;
@@ -324,12 +326,22 @@ impl Controller {
         message::deserialize_hw_errors(failed_modules, data)
             .map_err(Error::from)
             .map(|hw_errors| {
+                let mut unknowns = hw_errors.unknowns.clone();
                 let errors = hw_errors
+                    .errors
                     .into_iter()
                     .zip(failed_modules.to_indices())
-                    .map(|(source, module_index)| TransceiverError::Hardware {
-                        module_index,
-                        source,
+                    .map(|(source, module_index)| {
+                        let unknown = if source == HwError::Unknown {
+                            MaybeUnknown(unknowns.pop())
+                        } else {
+                            MaybeUnknown(None)
+                        };
+                        TransceiverError::Hardware {
+                            module_index,
+                            source,
+                            unknown,
+                        }
                     })
                     .collect();
                 FailedModules {
@@ -1393,6 +1405,7 @@ mod tests {
     use crate::test_utils;
     use crate::Controller;
     use crate::Error;
+    use crate::MaybeUnknown;
     use crate::PowerMode;
     use crate::TransceiverError;
     use crate::NUM_OUTSTANDING_REQUESTS;
@@ -1418,6 +1431,7 @@ mod tests {
     use transceiver_messages::message::MessageBody;
     use transceiver_messages::message::SpResponse;
     use transceiver_messages::message::Status;
+    use transceiver_messages::message::Unknowns;
     use transceiver_messages::mgmt::cmis;
     use transceiver_messages::mgmt::sff8636;
     use transceiver_messages::mgmt::MemoryRead;
@@ -1679,6 +1693,7 @@ mod tests {
         let received_errors = vec![TransceiverError::Hardware {
             module_index: 0,
             source: errors[0].clone(),
+            unknown: MaybeUnknown(None),
         }];
         let expected_requests = vec![
             Message::new(MessageBody::HostRequest(HostRequest::Read {
@@ -1781,6 +1796,113 @@ mod tests {
         simple_ack_op(HostRequest::ClearPowerFault).await;
     }
 
+    // Test that an unrecognized error byte from the SP is reported as
+    // HwError::Unknown with the raw byte captured in MaybeUnknown.
+    #[tokio::test]
+    async fn test_unknown_unknown_hw_error() {
+        let (controller, socket) = peer_setup().await;
+
+        let modules = ModuleId(0b01);
+        let failed_modules = ModuleId(0b01);
+
+        // 0xFF is not a valid HwError variant, so it will be decoded as
+        // HwError::Unknown with the raw byte preserved in MaybeUnknown.
+        let unknown_byte: u8 = 0xFF;
+        let expected_errors = vec![TransceiverError::Hardware {
+            module_index: 0,
+            source: HwError::Unknown,
+            unknown: MaybeUnknown(Some(Unknowns::UnknownUnknown(unknown_byte))),
+        }];
+
+        let expected_requests = vec![Message::new(MessageBody::HostRequest(
+            HostRequest::AssertReset(modules),
+        ))];
+        let responses = vec![(
+            Message::new(MessageBody::SpResponse(SpResponse::Ack {
+                modules: ModuleId::empty(),
+                failed_modules,
+            })),
+            Some(vec![unknown_byte]),
+        )];
+
+        let (ded, ded_rx) = oneshot::channel();
+        let sp = MockSp {
+            socket,
+            expected_requests,
+            responses,
+            ded: Some(ded),
+        };
+        let _sp_task = tokio::spawn(sp.run());
+
+        let task = tokio::spawn(async move { controller.assert_reset(modules).await });
+        ded_rx.await.unwrap().expect("MockSp panicked");
+        let result = task.await.unwrap().unwrap();
+        assert_eq!(
+            result,
+            AckResult {
+                modules: ModuleId::empty(),
+                data: vec![],
+                failures: FailedModules {
+                    modules: failed_modules,
+                    errors: expected_errors,
+                },
+            }
+        );
+    }
+
+    // Test that an HwError::Uknown from the SP is reported as
+    // HwError::Unknown without a raw byte also captured.
+    #[tokio::test]
+    async fn test_known_unknown_hw_error() {
+        let (controller, socket) = peer_setup().await;
+
+        let modules = ModuleId(0b01);
+        let failed_modules = ModuleId(0b01);
+
+        // HwError::Unknown is a known variant and thus we shouldn't capture the byte
+        let hw_unknown: u8 = HwError::Unknown as u8;
+        let expected_errors = vec![TransceiverError::Hardware {
+            module_index: 0,
+            source: HwError::Unknown,
+            unknown: MaybeUnknown(Some(Unknowns::KnownUnknown)),
+        }];
+
+        let expected_requests = vec![Message::new(MessageBody::HostRequest(
+            HostRequest::AssertReset(modules),
+        ))];
+        let responses = vec![(
+            Message::new(MessageBody::SpResponse(SpResponse::Ack {
+                modules: ModuleId::empty(),
+                failed_modules,
+            })),
+            Some(vec![hw_unknown]),
+        )];
+
+        let (ded, ded_rx) = oneshot::channel();
+        let sp = MockSp {
+            socket,
+            expected_requests,
+            responses,
+            ded: Some(ded),
+        };
+        let _sp_task = tokio::spawn(sp.run());
+
+        let task = tokio::spawn(async move { controller.assert_reset(modules).await });
+        ded_rx.await.unwrap().expect("MockSp panicked");
+        let result = task.await.unwrap().unwrap();
+        assert_eq!(
+            result,
+            AckResult {
+                modules: ModuleId::empty(),
+                data: vec![],
+                failures: FailedModules {
+                    modules: failed_modules,
+                    errors: expected_errors,
+                },
+            }
+        );
+    }
+
     // Helper function to run a bunch of tests, which generally just send some
     // simple host request and await an ACK. E.g., assert reset and disable
     // power are fundamentally the same, with a slightly different method and
@@ -1798,6 +1920,7 @@ mod tests {
         let received_errors = vec![TransceiverError::Hardware {
             module_index: 0,
             source: errors[0].clone(),
+            unknown: MaybeUnknown(None),
         }];
         let request = req(modules);
         let expected_requests = vec![Message::new(MessageBody::HostRequest(request)); 2];
@@ -2196,6 +2319,7 @@ mod tests {
         let expected_status_err = vec![TransceiverError::Hardware {
             module_index: 0,
             source: HwError::FpgaError,
+            unknown: MaybeUnknown(None),
         }];
         let expected_status_err_data = serialize_vec(&[HwError::FpgaError]);
 
@@ -2211,6 +2335,7 @@ mod tests {
         let expected_ident_err = vec![TransceiverError::Hardware {
             module_index: 1,
             source: HwError::FpgaError,
+            unknown: MaybeUnknown(None),
         }];
         let expected_ident_err_data = serialize_vec(&[HwError::FpgaError]);
 
@@ -2229,6 +2354,7 @@ mod tests {
         let expected_power_err = vec![TransceiverError::Hardware {
             module_index: 2,
             source: HwError::FpgaError,
+            unknown: MaybeUnknown(None),
         }];
         let expected_power_err_data = serialize_vec(&[HwError::FpgaError]);
 
@@ -2397,14 +2523,17 @@ mod tests {
                         TransceiverError::Hardware {
                             module_index: 0,
                             source: failed_lp_mode_err[0],
+                            unknown: MaybeUnknown(None),
                         },
                         TransceiverError::Hardware {
                             module_index: 1,
                             source: failed_reset_err[0],
+                            unknown: MaybeUnknown(None),
                         },
                         TransceiverError::Hardware {
                             module_index: 2,
                             source: failed_disable_power_err[0],
+                            unknown: MaybeUnknown(None),
                         },
                     ],
                 }
@@ -2511,6 +2640,7 @@ mod tests {
         let received_errors = vec![TransceiverError::Hardware {
             module_index: cmis_module.to_indices().next().unwrap(),
             source: errors[0].clone(),
+            unknown: MaybeUnknown(None),
         }];
 
         // We expect a few different requests:

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -328,14 +328,13 @@ impl Controller {
                 let errors = hw_errors
                     .into_iter()
                     .zip(failed_modules.to_indices())
-                    .map(|(error, module_index)| {
-                        let (hw_err, unknown) = error;
-                        TransceiverError::Hardware {
+                    .map(
+                        |(&(hw_error, unknown), module_index)| TransceiverError::Hardware {
                             module_index,
-                            source: *hw_err,
-                            unknown: MaybeUnknown(*unknown),
-                        }
-                    })
+                            source: hw_error,
+                            unknown: MaybeUnknown(unknown),
+                        },
+                    )
                     .collect();
                 FailedModules {
                     modules: failed_modules,

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -47,7 +47,6 @@ use transceiver_messages::merge_module_data;
 use transceiver_messages::message;
 use transceiver_messages::message::Header;
 use transceiver_messages::message::HostRequest;
-use transceiver_messages::message::HwError;
 pub use transceiver_messages::message::LedState;
 use transceiver_messages::message::MacAddrResponse;
 use transceiver_messages::message::Message;
@@ -326,21 +325,15 @@ impl Controller {
         message::deserialize_hw_errors(failed_modules, data)
             .map_err(Error::from)
             .map(|hw_errors| {
-                let mut unknowns = hw_errors.unknowns.clone();
                 let errors = hw_errors
-                    .errors
                     .into_iter()
                     .zip(failed_modules.to_indices())
-                    .map(|(source, module_index)| {
-                        let unknown = if source == HwError::Unknown {
-                            MaybeUnknown(unknowns.pop())
-                        } else {
-                            MaybeUnknown(None)
-                        };
+                    .map(|(error, module_index)| {
+                        let (hw_err, unknown) = error;
                         TransceiverError::Hardware {
                             module_index,
-                            source,
-                            unknown,
+                            source: *hw_err,
+                            unknown: MaybeUnknown(*unknown),
                         }
                     })
                     .collect();

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -68,7 +68,9 @@ pub use crate::controller::Controller;
 pub use crate::messages::*;
 pub use crate::results::*;
 pub use large_access::LargeMemoryAccess;
+use transceiver_messages::message::Unknowns;
 
+use std::fmt;
 use std::net::IpAddr;
 pub use transceiver_decode::Error as DecodeError;
 pub use transceiver_decode::*;
@@ -132,15 +134,33 @@ mod probes {
     fn message__dropped(header: &Header, message: &Message, reason: &str) {}
 }
 
+/// An optional unknown hardware error code, printed only when present.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MaybeUnknown(pub Option<Unknowns>);
+
+impl fmt::Display for MaybeUnknown {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(v) = self.0 {
+            match v {
+                Unknowns::UnknownUnknown(byte) => write!(f, " (unknown: {byte:#04x})"),
+                Unknowns::KnownUnknown => Ok(()),
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
 /// An error operating on a transceiver, such as a bad index, hardware failure,
 /// or error decoding its memory map.
 #[derive(Clone, Copy, Debug, PartialEq, thiserror::Error)]
 pub enum TransceiverError {
-    #[error("Hardware error accessing module {module_index}: {source}")]
+    #[error("Hardware error accessing module {module_index}: {source}{unknown}")]
     Hardware {
         module_index: u8,
         #[source]
         source: HwError,
+        unknown: MaybeUnknown,
     },
 
     #[error("Error decoding module data: {0}")]

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -142,8 +142,8 @@ impl fmt::Display for MaybeUnknown {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(v) = self.0 {
             match v {
-                Unknowns::UnknownUnknown(byte) => write!(f, " (unknown: {byte:#04x})"),
-                Unknowns::KnownUnknown => Ok(()),
+                Unknowns::UnknownUnknown(byte) => write!(f, " (could not deserialize {byte:#04x})"),
+                Unknowns::KnownUnknown => write!(f, " (peer sent HwError::Unknown)"),
             }
         } else {
             Ok(())

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -66,7 +66,10 @@ pub mod version {
         /// Addition to HwError: I2cTransactionTimeout
         pub const V6: u8 = 6;
 
-        pub const CURRENT: u8 = V6;
+        /// Addition to HwError: Unknown
+        pub const V7: u8 = 7;
+
+        pub const CURRENT: u8 = V7;
         pub const MIN: u8 = V1;
     }
     pub mod outer {
@@ -213,6 +216,58 @@ pub enum HwError {
         error("The I2C transaction to the module timed out")
     )]
     I2cTransactionTimeout,
+
+    /// We received an error we don't know how to deserialize.
+    ///
+    /// We have received an error which we are unsure how to deserialize, so
+    /// we map it to this variant so we can continue to decode the message.
+    /// This can happen when the controller and the SP are running different
+    /// versions of the protocol, such as during an update.
+    #[cfg_attr(any(test, feature = "std"), error("Received an unknown error type"))]
+    Unknown,
+}
+
+/// A Rumsfeldian enum to assist in the cases where we can end up with
+/// HwError::Unknown when deserializing messages from a peer. It is important
+/// to be able to differentiate between the case where the peer explicitly sent
+/// it to us (unexpected in practice) and when we fail to deserialize an error
+/// from the peer. In the later we want to preserve the data we failed to
+/// deserialize so it can be utilized by the controller when printing an error
+/// message.
+#[cfg(feature = "std")]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Unknowns {
+    KnownUnknown,       // The peer sent us an actual HwError::Unknown
+    UnknownUnknown(u8), // We got a byte we don't know how to decode
+}
+
+/// When a HwError::Unknown is pushed into `errors`, an approprate Unknowns
+/// should be pushed into `unknowns`.
+#[cfg(feature = "std")]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeserializedErrors {
+    pub errors: Vec<HwError>,
+    pub unknowns: Vec<Unknowns>,
+}
+
+#[cfg(feature = "std")]
+impl DeserializedErrors {
+    pub fn new(error_count: usize) -> Self {
+        Self {
+            errors: Vec::with_capacity(error_count),
+            unknowns: Vec::new(),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl Default for DeserializedErrors {
+    fn default() -> Self {
+        Self {
+            errors: Vec::new(),
+            unknowns: Vec::new(),
+        }
+    }
 }
 
 /// Deserialize the [`HwError`]s from a packet buffer that are expected, given
@@ -233,9 +288,9 @@ pub enum HwError {
 pub fn deserialize_hw_errors(
     failed_modules: ModuleId,
     buf: &[u8],
-) -> Result<Vec<HwError>, ProtocolError> {
+) -> Result<DeserializedErrors, ProtocolError> {
     match failed_modules.selected_transceiver_count() {
-        0 => Ok(vec![]),
+        0 => Ok(DeserializedErrors::default()),
         n => {
             const ITEM_SIZE: usize = HwError::MAX_SIZE;
             let n_bytes = n * ITEM_SIZE;
@@ -245,15 +300,29 @@ pub fn deserialize_hw_errors(
                     actual: u32::try_from(buf.len()).unwrap(),
                 });
             }
-            let mut out = Vec::with_capacity(n);
+            let mut out = DeserializedErrors::new(n);
             let chunks = buf.chunks_exact(ITEM_SIZE);
             for chunk in chunks {
-                out.push(
-                    hubpack::deserialize(chunk)
-                        .map_err(|_| ProtocolError::Serialization)?
-                        .0,
-                );
+                match hubpack::deserialize(chunk).map_err(|_| ProtocolError::Serialization) {
+                    Ok(hwerr) => {
+                        out.errors.push(hwerr.0);
+                        // We need to check if the peer sent us a HwError::Unknown
+                        // intentionally. In practice this shouldn't happen, but
+                        // if it did and we didn't account for it then we could lose
+                        // information about actual serialization failures.
+                        if hwerr.0 == HwError::Unknown {
+                            out.unknowns.push(Unknowns::KnownUnknown);
+                        }
+                    }
+                    Err(_) => {
+                        out.errors.push(HwError::Unknown);
+                        out.unknowns.push(Unknowns::UnknownUnknown(chunk[0]));
+                    }
+                }
             }
+            // We want to use the unknowns vec like a queue, so we reverse it
+            // to support popping entries in the order they were added.
+            out.unknowns.reverse();
             Ok(out)
         }
     }
@@ -994,6 +1063,7 @@ mod test {
     use crate::mac::BadMacAddrReason;
     use crate::mac::MacAddrs;
     use crate::message::deserialize_hw_errors;
+    use crate::message::DeserializedErrors;
     use crate::message::ExtendedStatus;
     use crate::message::Header;
     use crate::message::HostRequest;
@@ -1006,6 +1076,7 @@ mod test {
     use crate::message::ProtocolError;
     use crate::message::SpResponse;
     use crate::message::Status;
+    use crate::message::Unknowns;
     use crate::mgmt::sff8636;
     use crate::mgmt::ManagementInterface;
     use crate::mgmt::MemoryRead;
@@ -1082,7 +1153,7 @@ mod test {
     #[test]
     fn test_hardware_error_encoding_unchanged() {
         let mut buf = [0u8; HwError::MAX_SIZE];
-        const TEST_DATA: [HwError; 14] = [
+        const TEST_DATA: [HwError; 15] = [
             HwError::I2cError,
             HwError::InvalidModuleIndex,
             HwError::FpgaError,
@@ -1097,6 +1168,7 @@ mod test {
             HwError::I2cByteNack,
             HwError::I2cSclStretchTimeout,
             HwError::I2cTransactionTimeout,
+            HwError::Unknown,
         ];
 
         for (variant_id, variant) in TEST_DATA.iter().enumerate() {
@@ -1429,7 +1501,10 @@ mod test {
     #[test]
     fn test_deserialize_hw_errors() {
         let modules = ModuleId(0);
-        assert_eq!(deserialize_hw_errors(modules, &[0; 8]).unwrap(), vec![]);
+        assert_eq!(
+            deserialize_hw_errors(modules, &[0; 8]).unwrap(),
+            DeserializedErrors::default()
+        );
 
         let modules = ModuleId(1);
         assert_eq!(
@@ -1443,7 +1518,30 @@ mod test {
         let modules = ModuleId(1);
         assert_eq!(
             deserialize_hw_errors(modules, &[0]).unwrap(),
-            vec![HwError::I2cError],
+            DeserializedErrors {
+                errors: vec![HwError::I2cError],
+                unknowns: vec![],
+            },
+        );
+
+        // peer sent a HwError we don't know about
+        let modules = ModuleId(2);
+        assert_eq!(
+            deserialize_hw_errors(modules, &[255]).unwrap(),
+            DeserializedErrors {
+                errors: vec![HwError::Unknown],
+                unknowns: vec![Unknowns::UnknownUnknown(255)],
+            },
+        );
+
+        // peer intentionally sends an HwError::Unknown
+        let modules = ModuleId(4);
+        assert_eq!(
+            deserialize_hw_errors(modules, &[HwError::Unknown as u8]).unwrap(),
+            DeserializedErrors {
+                errors: vec![HwError::Unknown],
+                unknowns: vec![Unknowns::KnownUnknown],
+            },
         );
     }
 

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -270,7 +270,7 @@ impl DeserializedErrors {
     }
 
     fn push(&mut self, chunk: &[u8]) {
-        let err = match hubpack::deserialize(chunk).map_err(|_| ProtocolError::Serialization) {
+        let err = match hubpack::deserialize(chunk) {
             Ok(hwerr) => {
                 let e = hwerr.0;
                 // We need to check if the peer sent us a HwError::Unknown

--- a/messages/src/message.rs
+++ b/messages/src/message.rs
@@ -241,32 +241,69 @@ pub enum Unknowns {
     UnknownUnknown(u8), // We got a byte we don't know how to decode
 }
 
-/// When a HwError::Unknown is pushed into `errors`, an approprate Unknowns
-/// should be pushed into `unknowns`.
+/// When a HwError::Unknown is present we can supply additional information
+/// we may have about it.
 #[cfg(feature = "std")]
 #[derive(Clone, Debug, PartialEq)]
 pub struct DeserializedErrors {
-    pub errors: Vec<HwError>,
-    pub unknowns: Vec<Unknowns>,
+    errors: Vec<(HwError, Option<Unknowns>)>,
 }
 
 #[cfg(feature = "std")]
 impl DeserializedErrors {
-    pub fn new(error_count: usize) -> Self {
-        Self {
-            errors: Vec::with_capacity(error_count),
-            unknowns: Vec::new(),
+    pub fn new(error_count: usize, buf: &[u8]) -> Result<Self, ProtocolError> {
+        const ITEM_SIZE: usize = HwError::MAX_SIZE;
+        let n_bytes = error_count * ITEM_SIZE;
+        if buf.len() < n_bytes {
+            return Err(ProtocolError::WrongDataSize {
+                expected: u32::try_from(n_bytes).unwrap(),
+                actual: u32::try_from(buf.len()).unwrap(),
+            });
         }
+        let mut d = Self {
+            errors: Vec::with_capacity(error_count),
+        };
+        for chunk in buf.chunks_exact(ITEM_SIZE) {
+            d.push(chunk)
+        }
+        Ok(d)
+    }
+
+    fn push(&mut self, chunk: &[u8]) {
+        let err = match hubpack::deserialize(chunk).map_err(|_| ProtocolError::Serialization) {
+            Ok(hwerr) => {
+                let e = hwerr.0;
+                // We need to check if the peer sent us a HwError::Unknown
+                // intentionally. In practice this shouldn't happen, but
+                // if it did and we didn't account for it then we could lose
+                // information about actual serialization failures.
+                let u = if hwerr.0 == HwError::Unknown {
+                    Some(Unknowns::KnownUnknown)
+                } else {
+                    None
+                };
+                (e, u)
+            }
+            Err(_) => (HwError::Unknown, Some(Unknowns::UnknownUnknown(chunk[0]))),
+        };
+        self.errors.push(err);
     }
 }
 
 #[cfg(feature = "std")]
 impl Default for DeserializedErrors {
     fn default() -> Self {
-        Self {
-            errors: Vec::new(),
-            unknowns: Vec::new(),
-        }
+        Self { errors: Vec::new() }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> IntoIterator for &'a DeserializedErrors {
+    type Item = &'a (HwError, Option<Unknowns>);
+    type IntoIter = core::slice::Iter<'a, (HwError, Option<Unknowns>)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.errors.iter()
     }
 }
 
@@ -291,40 +328,7 @@ pub fn deserialize_hw_errors(
 ) -> Result<DeserializedErrors, ProtocolError> {
     match failed_modules.selected_transceiver_count() {
         0 => Ok(DeserializedErrors::default()),
-        n => {
-            const ITEM_SIZE: usize = HwError::MAX_SIZE;
-            let n_bytes = n * ITEM_SIZE;
-            if buf.len() < n_bytes {
-                return Err(ProtocolError::WrongDataSize {
-                    expected: u32::try_from(n_bytes).unwrap(),
-                    actual: u32::try_from(buf.len()).unwrap(),
-                });
-            }
-            let mut out = DeserializedErrors::new(n);
-            let chunks = buf.chunks_exact(ITEM_SIZE);
-            for chunk in chunks {
-                match hubpack::deserialize(chunk).map_err(|_| ProtocolError::Serialization) {
-                    Ok(hwerr) => {
-                        out.errors.push(hwerr.0);
-                        // We need to check if the peer sent us a HwError::Unknown
-                        // intentionally. In practice this shouldn't happen, but
-                        // if it did and we didn't account for it then we could lose
-                        // information about actual serialization failures.
-                        if hwerr.0 == HwError::Unknown {
-                            out.unknowns.push(Unknowns::KnownUnknown);
-                        }
-                    }
-                    Err(_) => {
-                        out.errors.push(HwError::Unknown);
-                        out.unknowns.push(Unknowns::UnknownUnknown(chunk[0]));
-                    }
-                }
-            }
-            // We want to use the unknowns vec like a queue, so we reverse it
-            // to support popping entries in the order they were added.
-            out.unknowns.reverse();
-            Ok(out)
-        }
+        n => DeserializedErrors::new(n, buf),
     }
 }
 
@@ -1076,7 +1080,6 @@ mod test {
     use crate::message::ProtocolError;
     use crate::message::SpResponse;
     use crate::message::Status;
-    use crate::message::Unknowns;
     use crate::mgmt::sff8636;
     use crate::mgmt::ManagementInterface;
     use crate::mgmt::MemoryRead;
@@ -1518,30 +1521,22 @@ mod test {
         let modules = ModuleId(1);
         assert_eq!(
             deserialize_hw_errors(modules, &[0]).unwrap(),
-            DeserializedErrors {
-                errors: vec![HwError::I2cError],
-                unknowns: vec![],
-            },
+            DeserializedErrors::new(1, &[0]).unwrap()
         );
 
         // peer sent a HwError we don't know about
         let modules = ModuleId(2);
         assert_eq!(
             deserialize_hw_errors(modules, &[255]).unwrap(),
-            DeserializedErrors {
-                errors: vec![HwError::Unknown],
-                unknowns: vec![Unknowns::UnknownUnknown(255)],
-            },
+            DeserializedErrors::new(1, &[255]).unwrap()
         );
 
         // peer intentionally sends an HwError::Unknown
         let modules = ModuleId(4);
+        let unknown_byte = HwError::Unknown as u8;
         assert_eq!(
-            deserialize_hw_errors(modules, &[HwError::Unknown as u8]).unwrap(),
-            DeserializedErrors {
-                errors: vec![HwError::Unknown],
-                unknowns: vec![Unknowns::KnownUnknown],
-            },
+            deserialize_hw_errors(modules, &[unknown_byte]).unwrap(),
+            DeserializedErrors::new(1, &[unknown_byte]).unwrap()
         );
     }
 


### PR DESCRIPTION
This can happen when the controller and peer versions get out of synch, such as during an update. Current behavior is to throw a serialization error and trash the whole message. This commit allows us to complete deserialization in the event of an unknown HwError variant and display what the underlying value was which we didn't have the variant for.